### PR TITLE
[25 MRG] Electron: load Vite dev server in unpackaged/dev mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,3 +554,18 @@ Commercial Gomi builds should preserve these principles:
 ## License And Distribution Notes
 
 This repository is a Gomi IDE product foundation. Before commercial distribution, review Code - OSS license obligations, third-party dependency licenses, marketplace terms, branding rules, and generated asset rights.
+
+## Electron desktop shell
+
+`npm run build && npm run electron:start` loads the production `dist/index.html` bundle.
+
+For live Office UI iteration, start Vite then open Electron in dev mode:
+
+```bash
+npm run dev
+# other terminal:
+npm run electron:dev
+```
+
+`GOMI_ELECTRON_DEV=1` makes Electron load the Vite server (default `http://127.0.0.1:5173`). Optional overrides: `GOMI_VITE_DEV_URL`, `GOMI_VITE_PORT`. Packaged builds ignore these flags and always load the built index.
+

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1,5 +1,6 @@
 const { app, BrowserWindow, shell, Menu } = require('electron');
 const path = require('node:path');
+const { resolveRendererEntry } = require('./resolveRendererEntry.cjs');
 
 const isDev = !app.isPackaged;
 const rendererEntry = path.join(__dirname, '..', 'dist', 'index.html');
@@ -24,7 +25,17 @@ function createWindow() {
     window.show();
   });
 
-  void window.loadFile(rendererEntry);
+  const entry = resolveRendererEntry({
+    isPackaged: app.isPackaged,
+    env: process.env,
+    distIndexHtml: rendererEntry
+  });
+
+  if (entry.kind === 'url') {
+    void window.loadURL(entry.target);
+  } else {
+    void window.loadFile(entry.target);
+  }
 
   window.webContents.setWindowOpenHandler(({ url }) => {
     if (/^https?:\/\//i.test(url)) {
@@ -35,6 +46,14 @@ function createWindow() {
   });
 
   window.webContents.on('will-navigate', (event, url) => {
+    const allowDevServer =
+      entry.kind === 'url' &&
+      (url === entry.target || url.startsWith(entry.target.replace(/\/$/, '') + '/'));
+
+    if (allowDevServer) {
+      return;
+    }
+
     if (!url.startsWith('file://')) {
       event.preventDefault();
 

--- a/electron/resolveRendererEntry.cjs
+++ b/electron/resolveRendererEntry.cjs
@@ -1,0 +1,75 @@
+/**
+ * Pure helper: decide which URL/file Electron should load for the renderer.
+ * Packaged builds always use the built dist index. Unpackaged builds can opt
+ * into the Vite dev server via GOMI_ELECTRON_DEV=1 (or "true") and optional
+ * GOMI_VITE_DEV_URL / GOMI_VITE_PORT.
+ *
+ * @param {{
+ *   isPackaged: boolean,
+ *   env?: NodeJS.ProcessEnv | Record<string, string | undefined>,
+ *   distIndexHtml: string,
+ *   defaultDevUrl?: string
+ * }} options
+ * @returns {{ kind: 'url' | 'file', target: string, reason: string }}
+ */
+function resolveRendererEntry(options) {
+  const env = options.env || {};
+  const distIndexHtml = options.distIndexHtml;
+  const defaultDevUrl = options.defaultDevUrl || 'http://127.0.0.1:5173';
+
+  if (options.isPackaged) {
+    return {
+      kind: 'file',
+      target: distIndexHtml,
+      reason: 'packaged'
+    };
+  }
+
+  const flag = String(env.GOMI_ELECTRON_DEV || '').trim().toLowerCase();
+  const wantsDev = flag === '1' || flag === 'true' || flag === 'yes';
+
+  if (!wantsDev) {
+    return {
+      kind: 'file',
+      target: distIndexHtml,
+      reason: 'unpackaged-without-dev-flag'
+    };
+  }
+
+  const explicitUrl = String(env.GOMI_VITE_DEV_URL || '').trim();
+  if (explicitUrl) {
+    if (!/^https?:\/\//i.test(explicitUrl)) {
+      throw new Error(
+        `GOMI_VITE_DEV_URL must be an http(s) URL, got: ${explicitUrl}`
+      );
+    }
+    return {
+      kind: 'url',
+      target: explicitUrl,
+      reason: 'explicit-dev-url'
+    };
+  }
+
+  const portRaw = String(env.GOMI_VITE_PORT || '').trim();
+  if (portRaw) {
+    const port = Number(portRaw);
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+      throw new Error(`GOMI_VITE_PORT must be an integer 1-65535, got: ${portRaw}`);
+    }
+    return {
+      kind: 'url',
+      target: `http://127.0.0.1:${port}`,
+      reason: 'dev-port'
+    };
+  }
+
+  return {
+    kind: 'url',
+    target: defaultDevUrl,
+    reason: 'default-dev-url'
+  };
+}
+
+module.exports = {
+  resolveRendererEntry
+};

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "typecheck": "tsc -b",
     "verify:release": "vitest run tests/releaseReadiness.test.ts tests/codeOssIntegrationManifest.test.ts",
     "electron:start": "electron .",
+    "electron:dev": "node scripts/run-electron-dev.mjs",
     "desktop:dir": "npm run build && electron-builder --win --dir",
     "desktop:build": "npm run build && electron-builder --win"
   },

--- a/scripts/run-electron-dev.mjs
+++ b/scripts/run-electron-dev.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+/**
+ * Launch Electron against the Vite dev server.
+ * Expects `npm run dev` (or another host on GOMI_VITE_DEV_URL / GOMI_VITE_PORT)
+ * to already be running unless you only want the shell to open.
+ */
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const electronBin = path.join(
+  root,
+  'node_modules',
+  '.bin',
+  process.platform === 'win32' ? 'electron.cmd' : 'electron'
+);
+
+const env = {
+  ...process.env,
+  GOMI_ELECTRON_DEV: process.env.GOMI_ELECTRON_DEV || '1'
+};
+
+const child = spawn(electronBin, ['.'], {
+  cwd: root,
+  env,
+  stdio: 'inherit',
+  shell: process.platform === 'win32'
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 0);
+});

--- a/tests/electronRendererEntry.test.ts
+++ b/tests/electronRendererEntry.test.ts
@@ -1,0 +1,98 @@
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const electronDir = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'electron');
+const { resolveRendererEntry } = require(path.join(electronDir, 'resolveRendererEntry.cjs')) as {
+  resolveRendererEntry: (options: {
+    isPackaged: boolean;
+    env?: Record<string, string | undefined>;
+    distIndexHtml: string;
+    defaultDevUrl?: string;
+  }) => { kind: 'url' | 'file'; target: string; reason: string };
+};
+
+const distIndex = path.join('D:', 'fake', 'dist', 'index.html');
+
+describe('resolveRendererEntry', () => {
+  it('always uses dist file when packaged', () => {
+    const result = resolveRendererEntry({
+      isPackaged: true,
+      env: { GOMI_ELECTRON_DEV: '1', GOMI_VITE_DEV_URL: 'http://127.0.0.1:5173' },
+      distIndexHtml: distIndex
+    });
+
+    expect(result).toEqual({
+      kind: 'file',
+      target: distIndex,
+      reason: 'packaged'
+    });
+  });
+
+  it('uses dist file when unpackaged without dev flag', () => {
+    const result = resolveRendererEntry({
+      isPackaged: false,
+      env: {},
+      distIndexHtml: distIndex
+    });
+
+    expect(result.kind).toBe('file');
+    expect(result.target).toBe(distIndex);
+    expect(result.reason).toBe('unpackaged-without-dev-flag');
+  });
+
+  it('loads default Vite URL when GOMI_ELECTRON_DEV=1', () => {
+    const result = resolveRendererEntry({
+      isPackaged: false,
+      env: { GOMI_ELECTRON_DEV: '1' },
+      distIndexHtml: distIndex
+    });
+
+    expect(result).toEqual({
+      kind: 'url',
+      target: 'http://127.0.0.1:5173',
+      reason: 'default-dev-url'
+    });
+  });
+
+  it('honors GOMI_VITE_PORT and GOMI_VITE_DEV_URL', () => {
+    expect(
+      resolveRendererEntry({
+        isPackaged: false,
+        env: { GOMI_ELECTRON_DEV: 'true', GOMI_VITE_PORT: '5199' },
+        distIndexHtml: distIndex
+      }).target
+    ).toBe('http://127.0.0.1:5199');
+
+    expect(
+      resolveRendererEntry({
+        isPackaged: false,
+        env: {
+          GOMI_ELECTRON_DEV: 'yes',
+          GOMI_VITE_DEV_URL: 'http://127.0.0.1:4173/'
+        },
+        distIndexHtml: distIndex
+      }).target
+    ).toBe('http://127.0.0.1:4173/');
+  });
+
+  it('rejects non-http dev URLs and invalid ports', () => {
+    expect(() =>
+      resolveRendererEntry({
+        isPackaged: false,
+        env: { GOMI_ELECTRON_DEV: '1', GOMI_VITE_DEV_URL: 'file:///tmp/x' },
+        distIndexHtml: distIndex
+      })
+    ).toThrow(/http\(s\) URL/i);
+
+    expect(() =>
+      resolveRendererEntry({
+        isPackaged: false,
+        env: { GOMI_ELECTRON_DEV: '1', GOMI_VITE_PORT: 'not-a-port' },
+        distIndexHtml: distIndex
+      })
+    ).toThrow(/GOMI_VITE_PORT/);
+  });
+});


### PR DESCRIPTION
## Summary
- Unpackaged Electron can load Vite via `GOMI_ELECTRON_DEV=1` (`npm run electron:dev`)
- Packaged builds always load `dist/index.html`
- Pure `resolveRendererEntry` helper + Vitest coverage
- Docs in README; external navigation still sandboxed (dev server navigation allowed)

## Linked
- Gomi #2
- MergeOS bounty intake: https://github.com/mergeos-bounties/mergeos/issues/244
- MergeOS task: `tsk_0144` / project `prj_0127`

## Test plan
- [x] `npm test -- tests/electronRendererEntry.test.ts` (5 passed)
- [ ] Manual: `npm run dev` + `npm run electron:dev` loads Office UI
- [ ] Manual: `npm run build && npm run electron:start` still uses dist

## Evidence
`
npm test -- tests/electronRendererEntry.test.ts
# Test Files  1 passed (1)
# Tests  5 passed (5)
`

## Reward
25 MRG (future-small) after merge via MergeOS admin ledger to PR author.