### PR TITLE
Add memory prune report action

### DIFF
--- a/src/vs/workbench/contrib/gomi/browser/GomiOfficeApp.tsx
+++ b/src/vs/workbench/contrib/gomi/browser/GomiOfficeApp.tsx
@@ -79,7 +79,7 @@ import type {
   GomiWorkspaceTrustState,
   GomiWorkspaceSnapshot
 } from '../common/gomiTypes';
-import { GomiAgentRuntime } from '../node/agentRuntime';
+import { GomiAgentRuntime, type GomiRuntimeMemoryPruneReport } from '../node/agentRuntime';
 import {
   approvePatchReview,
   canApplyPatch,
@@ -152,6 +152,9 @@ export function GomiOfficeApp() {
   const [report, setReport] = useState<GomiFinalReport | undefined>();
   const [patchReview, setPatchReview] = useState<GomiPatchReviewState | undefined>();
   const [workspace, setWorkspace] = useState<GomiWorkspaceSnapshot | undefined>();
+  const [memoryPruneReport, setMemoryPruneReport] = useState<GomiRuntimeMemoryPruneReport | undefined>();
+  const [memoryPruneError, setMemoryPruneError] = useState<string | undefined>();
+  const [isPruningMemory, setIsPruningMemory] = useState(false);
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [rightPanelCollapsed, setRightPanelCollapsed] = useState(() => isCompactAgentPanelViewport());
   const [bottomCollapsed, setBottomCollapsed] = useState(false);
@@ -236,6 +239,18 @@ export function GomiOfficeApp() {
 
           return markPatchPreviewOpened(currentReview, message.result);
         });
+      }
+
+      if (message.type === 'gomi.pruneMemoryResult') {
+        setIsPruningMemory(false);
+
+        if (message.error || !message.report) {
+          setMemoryPruneError(message.error ?? 'Memory prune did not return a report.');
+          return;
+        }
+
+        setMemoryPruneError(undefined);
+        setMemoryPruneReport(message.report);
       }
     });
   }, [workbenchBridge]);
@@ -372,6 +387,31 @@ export function GomiOfficeApp() {
 
       return markPatchApplied(applyingReview);
     });
+  }
+
+  async function pruneMemoryNow() {
+    if (isPruningMemory) {
+      return;
+    }
+
+    setIsPruningMemory(true);
+    setMemoryPruneError(undefined);
+
+    if (workbenchBridge) {
+      workbenchBridge.postMessage({
+        type: 'gomi.pruneMemory',
+        officeSettings
+      });
+      return;
+    }
+
+    try {
+      setMemoryPruneReport(await runtime.pruneMemory());
+    } catch (error) {
+      setMemoryPruneError(error instanceof Error ? error.message : 'Unknown memory prune error.');
+    } finally {
+      setIsPruningMemory(false);
+    }
   }
 
   function applyRuntimeEvent(event: GomiRuntimeEvent) {
@@ -709,6 +749,9 @@ export function GomiOfficeApp() {
           report={report}
           officeSettings={officeSettings}
           memoryItems={memoryItems}
+          memoryPruneReport={memoryPruneReport}
+          memoryPruneError={memoryPruneError}
+          isPruningMemory={isPruningMemory}
           onProviderChange={assignProvider}
           onToggleSeatSleep={toggleSeatSleep}
           onClosePanel={closeRightPanel}
@@ -731,6 +774,7 @@ export function GomiOfficeApp() {
           onCliProvidersEnabledChange={updateCliProvidersEnabled}
           onHttpProvidersEnabledChange={updateHttpProvidersEnabled}
           onLiveProviderPatchApprovalRequiredChange={updateLiveProviderPatchApprovalRequired}
+          onPruneMemory={pruneMemoryNow}
         />
       </div>
 
@@ -819,6 +863,9 @@ function RightPanel({
   report,
   officeSettings,
   memoryItems,
+  memoryPruneReport,
+  memoryPruneError,
+  isPruningMemory,
   onProviderChange,
   onToggleSeatSleep,
   onClosePanel,
@@ -840,13 +887,17 @@ function RightPanel({
   onLiveProviderModeChange,
   onCliProvidersEnabledChange,
   onHttpProvidersEnabledChange,
-  onLiveProviderPatchApprovalRequiredChange
+  onLiveProviderPatchApprovalRequiredChange,
+  onPruneMemory
 }: {
   agents: GomiAgent[];
   tasks: GomiTask[];
   report?: GomiFinalReport;
   officeSettings: GomiOfficeSettings;
   memoryItems: GomiMemoryBoardItem[];
+  memoryPruneReport?: GomiRuntimeMemoryPruneReport;
+  memoryPruneError?: string;
+  isPruningMemory: boolean;
   onProviderChange: (seatId: string, providerId: GomiAgentCliProviderId) => void;
   onToggleSeatSleep: (seat: GomiAgentSeat) => void;
   onClosePanel: () => void;
@@ -869,6 +920,7 @@ function RightPanel({
   onCliProvidersEnabledChange: (allowCliProviders: boolean) => void;
   onHttpProvidersEnabledChange: (allowHttpProviders: boolean) => void;
   onLiveProviderPatchApprovalRequiredChange: (requirePatchApprovalForLiveProviders: boolean) => void;
+  onPruneMemory: () => void;
 }) {
   return (
     <aside className="gomi-right-panel" aria-label="Agent Status Panel">
@@ -910,6 +962,9 @@ function RightPanel({
         <OfficeSettingsPanel
           officeSettings={officeSettings}
           memoryItems={memoryItems}
+          memoryPruneReport={memoryPruneReport}
+          memoryPruneError={memoryPruneError}
+          isPruningMemory={isPruningMemory}
           onProviderChange={onProviderChange}
           onToggleSeatSleep={onToggleSeatSleep}
           onHireEmployee={onHireEmployee}
@@ -931,6 +986,7 @@ function RightPanel({
           onCliProvidersEnabledChange={onCliProvidersEnabledChange}
           onHttpProvidersEnabledChange={onHttpProvidersEnabledChange}
           onLiveProviderPatchApprovalRequiredChange={onLiveProviderPatchApprovalRequiredChange}
+          onPruneMemory={onPruneMemory}
         />
       </div>
     </aside>
@@ -974,6 +1030,9 @@ function TaskRow({ task }: { task: GomiTask }) {
 function OfficeSettingsPanel({
   officeSettings,
   memoryItems,
+  memoryPruneReport,
+  memoryPruneError,
+  isPruningMemory,
   onProviderChange,
   onToggleSeatSleep,
   onHireEmployee,
@@ -994,10 +1053,14 @@ function OfficeSettingsPanel({
   onLiveProviderModeChange,
   onCliProvidersEnabledChange,
   onHttpProvidersEnabledChange,
-  onLiveProviderPatchApprovalRequiredChange
+  onLiveProviderPatchApprovalRequiredChange,
+  onPruneMemory
 }: {
   officeSettings: GomiOfficeSettings;
   memoryItems: GomiMemoryBoardItem[];
+  memoryPruneReport?: GomiRuntimeMemoryPruneReport;
+  memoryPruneError?: string;
+  isPruningMemory: boolean;
   onProviderChange: (seatId: string, providerId: GomiAgentCliProviderId) => void;
   onToggleSeatSleep: (seat: GomiAgentSeat) => void;
   onHireEmployee: (departmentId: GomiAgentId) => void;
@@ -1019,6 +1082,7 @@ function OfficeSettingsPanel({
   onCliProvidersEnabledChange: (allowCliProviders: boolean) => void;
   onHttpProvidersEnabledChange: (allowHttpProviders: boolean) => void;
   onLiveProviderPatchApprovalRequiredChange: (requirePatchApprovalForLiveProviders: boolean) => void;
+  onPruneMemory: () => void;
 }) {
   const leaders = officeSettings.seats.filter((seat) => seat.seatKind !== 'employee');
   const employees = officeSettings.seats.filter((seat) => seat.seatKind === 'employee');
@@ -1144,7 +1208,17 @@ function OfficeSettingsPanel({
       </div>
 
       <div className="gomi-settings-group">
-        <div className="gomi-settings-title">Shared Memory</div>
+        <div className="gomi-settings-title-row">
+          <div className="gomi-settings-title">Shared Memory</div>
+          <button
+            className="gomi-action-button"
+            onClick={onPruneMemory}
+            disabled={isPruningMemory}
+          >
+            <Database size={14} />
+            <span>{isPruningMemory ? 'Pruning' : 'Prune Now'}</span>
+          </button>
+        </div>
         <div className="gomi-memory-summary">
           <span>{officeSettings.memory.retrievalMode}</span>
           <span>{getMemoryEmbeddingProviderLabel(officeSettings.memory.embeddingProvider)}</span>
@@ -1155,6 +1229,19 @@ function OfficeSettingsPanel({
           <span>{`${officeSettings.memory.retentionDays}d retention`}</span>
           <span>{officeSettings.memory.requirePatchApproval ? 'approval required' : 'auto apply allowed'}</span>
         </div>
+        {memoryPruneReport ? (
+          <div className="gomi-memory-summary" aria-live="polite">
+            <span>{`${memoryPruneReport.removed} removed`}</span>
+            <span>{`${memoryPruneReport.remaining} remaining`}</span>
+            <span>{`lexical ${memoryPruneReport.lexical.removed}/${memoryPruneReport.lexical.remaining}`}</span>
+            <span>{`vector ${memoryPruneReport.vector.removed}/${memoryPruneReport.vector.remaining}`}</span>
+          </div>
+        ) : undefined}
+        {memoryPruneError ? (
+          <div className="gomi-seat-note" role="alert">
+            {memoryPruneError}
+          </div>
+        ) : undefined}
         <label className="gomi-toggle-field">
           <input
             type="checkbox"

--- a/src/vs/workbench/contrib/gomi/browser/gomiWebviewHostController.ts
+++ b/src/vs/workbench/contrib/gomi/browser/gomiWebviewHostController.ts
@@ -1,11 +1,17 @@
 import { normalizeGomiOfficeSettings } from '../common/gomiOfficeSettings';
 import type { GomiOfficeSettings, GomiPatchPreviewResult, GomiRuntimeEvent } from '../common/gomiTypes';
 import type { GomiBridgeMessage, GomiWorkbenchBridge } from '../electron-sandbox/gomiBridge';
-import { GomiAgentRuntime, type GomiRuntimeOptions, type GomiRuntimeRunOptions } from '../node/agentRuntime';
+import {
+  GomiAgentRuntime,
+  type GomiRuntimeMemoryPruneReport,
+  type GomiRuntimeOptions,
+  type GomiRuntimeRunOptions
+} from '../node/agentRuntime';
 import type { GomiPatchApplyResult } from '../node/workspacePatchApplier';
 
 export interface GomiWebviewRuntimeRunner {
   run(request: string, options?: GomiRuntimeRunOptions): AsyncGenerator<GomiRuntimeEvent>;
+  pruneMemory?: () => Promise<GomiRuntimeMemoryPruneReport>;
 }
 
 export interface GomiWebviewHostControllerOptions {
@@ -56,6 +62,11 @@ export class GomiWebviewHostController {
 
     if (message.type === 'gomi.stop') {
       this.stopOfficeSession(message.reason);
+      return;
+    }
+
+    if (message.type === 'gomi.pruneMemory') {
+      await this.pruneMemory(message);
       return;
     }
 
@@ -120,6 +131,26 @@ export class GomiWebviewHostController {
 
     this.postSystemMessage('Stopping the current Gomi Office session...');
     this.abortController.abort(reason);
+  }
+
+  private async pruneMemory(message: Extract<GomiBridgeMessage, { type: 'gomi.pruneMemory' }>): Promise<void> {
+    try {
+      const runtime = this.options.runtime ?? this.createRuntime(message.officeSettings);
+
+      if (!runtime.pruneMemory) {
+        throw new Error('Memory pruning is not configured for this Gomi webview host.');
+      }
+
+      this.options.bridge.postMessage({
+        type: 'gomi.pruneMemoryResult',
+        report: await runtime.pruneMemory()
+      });
+    } catch (error) {
+      this.options.bridge.postMessage({
+        type: 'gomi.pruneMemoryResult',
+        error: error instanceof Error ? error.message : 'Unknown memory prune error.'
+      });
+    }
   }
 
   private async applyPatch(message: Extract<GomiBridgeMessage, { type: 'gomi.applyPatch' }>): Promise<void> {

--- a/src/vs/workbench/contrib/gomi/electron-sandbox/gomiBridge.ts
+++ b/src/vs/workbench/contrib/gomi/electron-sandbox/gomiBridge.ts
@@ -4,6 +4,7 @@ import type {
   GomiPatchProposal,
   GomiRuntimeEvent
 } from '../common/gomiTypes';
+import type { GomiRuntimeMemoryPruneReport } from '../node/agentRuntime';
 import type { GomiPatchApplyResult } from '../node/workspacePatchApplier';
 
 export type GomiBridgeMessage =
@@ -15,6 +16,15 @@ export type GomiBridgeMessage =
   | {
       type: 'gomi.stop';
       reason?: string;
+    }
+  | {
+      type: 'gomi.pruneMemory';
+      officeSettings?: GomiOfficeSettings;
+    }
+  | {
+      type: 'gomi.pruneMemoryResult';
+      report?: GomiRuntimeMemoryPruneReport;
+      error?: string;
     }
   | {
       type: 'gomi.event';

--- a/src/vs/workbench/contrib/gomi/node/agentRuntime.ts
+++ b/src/vs/workbench/contrib/gomi/node/agentRuntime.ts
@@ -28,6 +28,8 @@ import {
   createInMemoryGomiMemoryStore,
   createMemoryContent,
   type GomiMemoryItem,
+  type GomiMemoryPruneReport,
+  type GomiMemoryScope,
   type GomiMemoryStore
 } from './memoryStore';
 import { GomiMessageBus } from './messageBus';
@@ -64,6 +66,11 @@ export interface GomiRuntimeRunOptions {
   stopReason?: string;
 }
 
+export interface GomiRuntimeMemoryPruneReport extends GomiMemoryPruneReport {
+  lexical: GomiMemoryPruneReport;
+  vector: GomiMemoryPruneReport;
+}
+
 export class GomiAgentRuntime {
   private readonly planner = new GomiTaskPlanner();
   private readonly bus = new GomiMessageBus<GomiRuntimeEvent>();
@@ -91,6 +98,14 @@ export class GomiAgentRuntime {
     return this.bus.subscribe(type, listener);
   }
 
+  async pruneMemory(): Promise<GomiRuntimeMemoryPruneReport> {
+    const workspace = await this.workspaceReader();
+
+    return this.pruneMemoryScope({
+      workspaceId: workspace.rootName
+    });
+  }
+
   async *run(request: string, options: GomiRuntimeRunOptions = {}): AsyncGenerator<GomiRuntimeEvent> {
     const sessionId = `gomi-${Date.now()}`;
     const signal = options.signal;
@@ -111,8 +126,7 @@ export class GomiAgentRuntime {
     };
     const sharedMemoryEnabled = this.officeSettings.memory.sharedMemoryEnabled;
 
-    this.memoryStore.prune(memoryScope, this.officeSettings.memory);
-    this.vectorMemoryStore.prune(memoryScope, this.officeSettings.memory);
+    this.pruneMemoryScope(memoryScope);
 
     const memoryPolicyResult = applyWorkspaceMemoryPolicy(rawWorkspace, this.officeSettings.memory);
     const workspace = memoryPolicyResult.workspace;
@@ -336,6 +350,18 @@ export class GomiAgentRuntime {
   private async *emit(event: GomiRuntimeEvent): AsyncGenerator<GomiRuntimeEvent> {
     this.bus.publish(event);
     yield event;
+  }
+
+  private pruneMemoryScope(scope: GomiMemoryScope): GomiRuntimeMemoryPruneReport {
+    const lexical = this.memoryStore.prune(scope, this.officeSettings.memory);
+    const vector = this.vectorMemoryStore.prune(scope, this.officeSettings.memory);
+
+    return {
+      removed: lexical.removed + vector.removed,
+      remaining: lexical.remaining + vector.remaining,
+      lexical,
+      vector
+    };
   }
 
   private async *say(

--- a/src/vs/workbench/contrib/gomi/node/gomiWorkbenchController.ts
+++ b/src/vs/workbench/contrib/gomi/node/gomiWorkbenchController.ts
@@ -7,7 +7,12 @@ import type {
   GomiPatchPreviewResult,
   GomiRuntimeEvent
 } from '../common/gomiTypes';
-import { GomiAgentRuntime, type GomiRuntimeOptions, type GomiRuntimeRunOptions } from './agentRuntime';
+import {
+  GomiAgentRuntime,
+  type GomiRuntimeMemoryPruneReport,
+  type GomiRuntimeOptions,
+  type GomiRuntimeRunOptions
+} from './agentRuntime';
 import type { GomiCliCommandRunner } from './cliAgentProvider';
 import {
   createConfiguredEmbeddingProvider,
@@ -29,6 +34,7 @@ import { createWorkbenchGomiAgentProvider } from './workbenchAgentProvider';
 
 export interface GomiRuntimeRunner {
   run(request: string, options?: GomiRuntimeRunOptions): AsyncGenerator<GomiRuntimeEvent>;
+  pruneMemory?: () => Promise<GomiRuntimeMemoryPruneReport>;
 }
 
 export interface GomiWorkbenchControllerOptions {
@@ -142,6 +148,11 @@ export class GomiWorkbenchController {
       return;
     }
 
+    if (message.type === 'gomi.pruneMemory') {
+      await this.pruneMemory(message);
+      return;
+    }
+
     if (message.type === 'gomi.applyPatch') {
       await this.applyPatchMessage(message);
       return;
@@ -203,6 +214,28 @@ export class GomiWorkbenchController {
 
     this.postSystemMessage('Stopping the current Gomi Office session...');
     this.abortController.abort(reason);
+  }
+
+  private async pruneMemory(
+    message: Extract<GomiBridgeMessage, { type: 'gomi.pruneMemory' }>
+  ): Promise<void> {
+    try {
+      const runtime = this.runtime ?? this.runtimeFactory(message.officeSettings);
+
+      if (!runtime.pruneMemory) {
+        throw new Error('Memory pruning is not configured for this Gomi workbench controller.');
+      }
+
+      this.bridge.postMessage({
+        type: 'gomi.pruneMemoryResult',
+        report: await runtime.pruneMemory()
+      });
+    } catch (error) {
+      this.bridge.postMessage({
+        type: 'gomi.pruneMemoryResult',
+        error: error instanceof Error ? error.message : 'Unknown memory prune error.'
+      });
+    }
   }
 
   private async applyPatchMessage(

--- a/src/vs/workbench/contrib/gomi/node/memoryStore.ts
+++ b/src/vs/workbench/contrib/gomi/node/memoryStore.ts
@@ -25,11 +25,16 @@ export interface GomiMemoryRetentionPolicy {
   maxProjectMemoryItems: number;
 }
 
+export interface GomiMemoryPruneReport {
+  removed: number;
+  remaining: number;
+}
+
 export interface GomiMemoryStore {
   get(scope: GomiMemoryScope, key: string): Promise<GomiMemoryItem | null>;
   put(scope: GomiMemoryScope, item: Omit<GomiMemoryItem, 'createdAt' | 'updatedAt'>): Promise<GomiMemoryItem>;
   search(scope: GomiMemoryScope, query: string, limit?: number): Promise<GomiMemoryHit[]>;
-  prune(scope: GomiMemoryScope, policy: GomiMemoryRetentionPolicy): void;
+  prune(scope: GomiMemoryScope, policy: GomiMemoryRetentionPolicy): GomiMemoryPruneReport;
   add(entry: Omit<GomiMemoryEntry, 'id' | 'createdAt'>): GomiMemoryEntry;
   list(sessionId: string): GomiMemoryEntry[];
   recent(sessionId: string, limit: number): GomiMemoryEntry[];
@@ -74,12 +79,14 @@ export class InMemoryGomiMemoryStore implements GomiMemoryStore {
       .slice(0, limit);
   }
 
-  prune(scope: GomiMemoryScope, policy: GomiMemoryRetentionPolicy): void {
+  prune(scope: GomiMemoryScope, policy: GomiMemoryRetentionPolicy): GomiMemoryPruneReport {
     const scopePrefix = this.scopePrefix(scope);
     const cutoffTime = Date.now() - policy.retentionDays * 24 * 60 * 60 * 1000;
     const scopedEntries = Array.from(this.scopedItems.entries())
       .filter(([key]) => key.startsWith(scopePrefix))
       .sort((left, right) => memoryTimestamp(right[1]) - memoryTimestamp(left[1]));
+    const entryCountBefore = this.entries.length;
+    const scopedCountBefore = scopedEntries.length;
 
     for (const [key, item] of scopedEntries) {
       if (memoryTimestamp(item) < cutoffTime) {
@@ -96,6 +103,16 @@ export class InMemoryGomiMemoryStore implements GomiMemoryStore {
     }
 
     this.entries = this.entries.filter((entry) => Date.parse(entry.createdAt) >= cutoffTime);
+
+    const remainingScopedItems = Array.from(this.scopedItems.keys()).filter((key) =>
+      key.startsWith(scopePrefix)
+    ).length;
+    const remaining = remainingScopedItems + this.entries.length;
+
+    return {
+      removed: entryCountBefore + scopedCountBefore - remaining,
+      remaining
+    };
   }
 
   add(entry: Omit<GomiMemoryEntry, 'id' | 'createdAt'>): GomiMemoryEntry {

--- a/src/vs/workbench/contrib/gomi/node/persistentProjectMemory.ts
+++ b/src/vs/workbench/contrib/gomi/node/persistentProjectMemory.ts
@@ -4,6 +4,7 @@ import type { GomiMemoryEntry } from '../common/gomiTypes';
 import type {
   GomiMemoryHit,
   GomiMemoryItem,
+  GomiMemoryPruneReport,
   GomiMemoryRetentionPolicy,
   GomiMemoryScope,
   GomiMemoryStore
@@ -69,12 +70,14 @@ export class FileBackedGomiMemoryStore implements GomiMemoryStore {
       .slice(0, limit);
   }
 
-  prune(scope: GomiMemoryScope, policy: GomiMemoryRetentionPolicy): void {
+  prune(scope: GomiMemoryScope, policy: GomiMemoryRetentionPolicy): GomiMemoryPruneReport {
     const scopePrefix = this.scopePrefix(scope);
     const cutoffTime = Date.now() - policy.retentionDays * 24 * 60 * 60 * 1000;
     const scopedItems = Array.from(this.scopedItems.entries())
       .filter(([key]) => key.startsWith(scopePrefix))
       .sort((left, right) => memoryTimestamp(right[1]) - memoryTimestamp(left[1]));
+    const entryCountBefore = this.entries.length;
+    const scopedCountBefore = scopedItems.length;
 
     for (const [key, item] of scopedItems) {
       if (memoryTimestamp(item) < cutoffTime) {
@@ -92,6 +95,16 @@ export class FileBackedGomiMemoryStore implements GomiMemoryStore {
 
     this.entries = this.entries.filter((entry) => Date.parse(entry.createdAt) >= cutoffTime);
     this.persist();
+
+    const remainingScopedItems = Array.from(this.scopedItems.keys()).filter((key) =>
+      key.startsWith(scopePrefix)
+    ).length;
+    const remaining = remainingScopedItems + this.entries.length;
+
+    return {
+      removed: entryCountBefore + scopedCountBefore - remaining,
+      remaining
+    };
   }
 
   add(entry: Omit<GomiMemoryEntry, 'id' | 'createdAt'>): GomiMemoryEntry {
@@ -214,12 +227,13 @@ export class FileBackedVectorMemoryStore implements GomiVectorMemoryStore {
       .slice(0, limit);
   }
 
-  prune(scope: GomiMemoryScope, policy: GomiMemoryRetentionPolicy): void {
+  prune(scope: GomiMemoryScope, policy: GomiMemoryRetentionPolicy): GomiMemoryPruneReport {
     const scopePrefix = this.scopePrefix(scope);
     const cutoffTime = Date.now() - policy.retentionDays * 24 * 60 * 60 * 1000;
     const scopedRecords = Array.from(this.records.entries())
       .filter(([key]) => key.startsWith(scopePrefix))
       .sort((left, right) => memoryTimestamp(right[1]) - memoryTimestamp(left[1]));
+    const scopedCountBefore = scopedRecords.length;
 
     for (const [key, record] of scopedRecords) {
       if (memoryTimestamp(record) < cutoffTime) {
@@ -236,6 +250,15 @@ export class FileBackedVectorMemoryStore implements GomiVectorMemoryStore {
     }
 
     this.persist();
+
+    const remaining = Array.from(this.records.keys()).filter((key) =>
+      key.startsWith(scopePrefix)
+    ).length;
+
+    return {
+      removed: scopedCountBefore - remaining,
+      remaining
+    };
   }
 
   clear(scope?: GomiMemoryScope): void {

--- a/src/vs/workbench/contrib/gomi/node/vectorMemoryStore.ts
+++ b/src/vs/workbench/contrib/gomi/node/vectorMemoryStore.ts
@@ -1,6 +1,7 @@
 import type {
   GomiMemoryHit,
   GomiMemoryItem,
+  GomiMemoryPruneReport,
   GomiMemoryRetentionPolicy,
   GomiMemoryScope
 } from './memoryStore';
@@ -17,7 +18,7 @@ export interface GomiVectorMemoryRecord extends GomiMemoryItem {
 export interface GomiVectorMemoryStore {
   upsert(scope: GomiMemoryScope, item: Omit<GomiMemoryItem, 'createdAt' | 'updatedAt'>): Promise<GomiMemoryItem>;
   search(scope: GomiMemoryScope, query: string, limit?: number): Promise<GomiMemoryHit[]>;
-  prune(scope: GomiMemoryScope, policy: GomiMemoryRetentionPolicy): void;
+  prune(scope: GomiMemoryScope, policy: GomiMemoryRetentionPolicy): GomiMemoryPruneReport;
   clear(scope?: GomiMemoryScope): void;
 }
 
@@ -68,12 +69,13 @@ export class InMemoryVectorMemoryStore implements GomiVectorMemoryStore {
       .slice(0, limit);
   }
 
-  prune(scope: GomiMemoryScope, policy: GomiMemoryRetentionPolicy): void {
+  prune(scope: GomiMemoryScope, policy: GomiMemoryRetentionPolicy): GomiMemoryPruneReport {
     const scopePrefix = this.scopePrefix(scope);
     const cutoffTime = Date.now() - policy.retentionDays * 24 * 60 * 60 * 1000;
     const scopedRecords = Array.from(this.records.entries())
       .filter(([key]) => key.startsWith(scopePrefix))
       .sort((left, right) => memoryTimestamp(right[1]) - memoryTimestamp(left[1]));
+    const scopedCountBefore = scopedRecords.length;
 
     for (const [key, record] of scopedRecords) {
       if (memoryTimestamp(record) < cutoffTime) {
@@ -88,6 +90,15 @@ export class InMemoryVectorMemoryStore implements GomiVectorMemoryStore {
     for (const [key] of retainedScopedRecords.slice(policy.maxProjectMemoryItems)) {
       this.records.delete(key);
     }
+
+    const remaining = Array.from(this.records.keys()).filter((key) =>
+      key.startsWith(scopePrefix)
+    ).length;
+
+    return {
+      removed: scopedCountBefore - remaining,
+      remaining
+    };
   }
 
   clear(scope?: GomiMemoryScope): void {

--- a/tests/agentRuntime.test.ts
+++ b/tests/agentRuntime.test.ts
@@ -11,6 +11,8 @@ import {
 } from '../src/vs/workbench/contrib/gomi/common/gomiOfficeSettings';
 import { GomiAgentRuntime } from '../src/vs/workbench/contrib/gomi/node/agentRuntime';
 import { createDemoGomiAgentProvider, type GomiAgentRunContext } from '../src/vs/workbench/contrib/gomi/node/agentProvider';
+import { createInMemoryGomiMemoryStore } from '../src/vs/workbench/contrib/gomi/node/memoryStore';
+import { createInMemoryVectorMemoryStore } from '../src/vs/workbench/contrib/gomi/node/vectorMemoryStore';
 
 describe('GomiAgentRuntime', () => {
   it('streams a final report and patch proposal', async () => {
@@ -133,6 +135,67 @@ describe('GomiAgentRuntime', () => {
 
     expect(memorySources).toContain('session');
     expect(memorySources).not.toContain('project');
+  });
+
+  it('prunes memory explicitly and returns a combined removal report', async () => {
+    const memoryStore = createInMemoryGomiMemoryStore();
+    const vectorMemoryStore = createInMemoryVectorMemoryStore();
+    const scope = { workspaceId: 'ManualPruneWorkspace' };
+    const memorySettings = {
+      ...DEFAULT_GOMI_OFFICE_SETTINGS.memory,
+      maxProjectMemoryItems: 1
+    };
+
+    await memoryStore.put(scope, {
+      key: 'workspace:oldest',
+      value: 'Oldest lexical context'
+    });
+    await memoryStore.put(scope, {
+      key: 'workspace:middle',
+      value: 'Middle lexical context'
+    });
+    await memoryStore.put(scope, {
+      key: 'workspace:newest',
+      value: 'Newest lexical context'
+    });
+    await vectorMemoryStore.upsert(scope, {
+      key: 'agent:older',
+      value: 'Older vector context'
+    });
+    await vectorMemoryStore.upsert(scope, {
+      key: 'agent:newer',
+      value: 'Newer vector context'
+    });
+
+    const runtime = new GomiAgentRuntime({
+      delayMs: 0,
+      memoryStore,
+      vectorMemoryStore,
+      officeSettings: {
+        ...DEFAULT_GOMI_OFFICE_SETTINGS,
+        memory: memorySettings
+      },
+      workspaceReader: () => ({
+        rootName: 'ManualPruneWorkspace',
+        files: [],
+        openEditors: [],
+        gitSummary: 'Git clean.',
+        terminalSummary: 'Idle.'
+      })
+    });
+
+    await expect(runtime.pruneMemory()).resolves.toEqual({
+      removed: 3,
+      remaining: 2,
+      lexical: {
+        removed: 2,
+        remaining: 1
+      },
+      vector: {
+        removed: 1,
+        remaining: 1
+      }
+    });
   });
 
   it('sanitizes workspace context before indexing and planning', async () => {

--- a/tests/gomiWebviewHostController.test.ts
+++ b/tests/gomiWebviewHostController.test.ts
@@ -120,6 +120,54 @@ describe('Gomi webview host controller', () => {
     expect(eventTypes.at(-1)).toBe('session_completed');
   });
 
+  it('returns manual memory prune reports through the bridge', async () => {
+    const bridge = new MemoryBridge();
+    const controller = new GomiWebviewHostController({
+      bridge,
+      runtime: {
+        async *run() {
+          yield {
+            type: 'session_completed',
+            sessionId: 'unused'
+          } satisfies GomiRuntimeEvent;
+        },
+        pruneMemory: async () => ({
+          removed: 3,
+          remaining: 2,
+          lexical: {
+            removed: 2,
+            remaining: 1
+          },
+          vector: {
+            removed: 1,
+            remaining: 1
+          }
+        })
+      }
+    });
+
+    await controller.handleMessage({
+      type: 'gomi.pruneMemory',
+      officeSettings: DEFAULT_GOMI_OFFICE_SETTINGS
+    });
+
+    expect(bridge.outbox[0]).toEqual({
+      type: 'gomi.pruneMemoryResult',
+      report: {
+        removed: 3,
+        remaining: 2,
+        lexical: {
+          removed: 2,
+          remaining: 1
+        },
+        vector: {
+          removed: 1,
+          remaining: 1
+        }
+      }
+    });
+  });
+
   it('returns patch apply errors when no host patch applier is configured', async () => {
     const bridge = new MemoryBridge();
     const controller = new GomiWebviewHostController({ bridge });

--- a/tests/gomiWorkbenchController.test.ts
+++ b/tests/gomiWorkbenchController.test.ts
@@ -123,6 +123,55 @@ describe('GomiWorkbenchController', () => {
     expect(eventTypes.at(-1)).toBe('session_completed');
   });
 
+  it('returns manual memory prune reports through the workbench bridge', async () => {
+    const bridge = new MemoryWorkbenchBridge();
+    const controller = new GomiWorkbenchController({
+      bridge,
+      workspaceRoot,
+      runtime: {
+        async *run() {
+          yield {
+            type: 'session_completed',
+            sessionId: 'unused'
+          };
+        },
+        pruneMemory: async () => ({
+          removed: 4,
+          remaining: 3,
+          lexical: {
+            removed: 3,
+            remaining: 2
+          },
+          vector: {
+            removed: 1,
+            remaining: 1
+          }
+        })
+      }
+    });
+
+    await controller.handleMessage({
+      type: 'gomi.pruneMemory',
+      officeSettings: DEFAULT_GOMI_OFFICE_SETTINGS
+    });
+
+    expect(bridge.outbox[0]).toEqual({
+      type: 'gomi.pruneMemoryResult',
+      report: {
+        removed: 4,
+        remaining: 3,
+        lexical: {
+          removed: 3,
+          remaining: 2
+        },
+        vector: {
+          removed: 1,
+          remaining: 1
+        }
+      }
+    });
+  });
+
   it('applies an approved patch message inside the workspace', async () => {
     const bridge = new MemoryWorkbenchBridge();
     const controller = new GomiWorkbenchController({ bridge, workspaceRoot });

--- a/tests/persistentProjectMemory.test.ts
+++ b/tests/persistentProjectMemory.test.ts
@@ -163,6 +163,75 @@ describe('persistent project memory', () => {
     expect(store.list('session-1').map((entry) => entry.content)).toEqual(['Fresh request']);
   });
 
+  it('reports lexical prune removal and remaining counts', async () => {
+    const filePath = path.join(tempDirectory, 'lexical-memory.json');
+    const scope: GomiMemoryScope = { workspaceId: 'Gomi' };
+    const scopePrefix = 'Gomi:anonymous:default:';
+    const expiredDate = new Date(Date.now() - 45 * 24 * 60 * 60 * 1000).toISOString();
+    const recentDate = new Date().toISOString();
+
+    await fs.writeFile(
+      filePath,
+      JSON.stringify({
+        version: 1,
+        entries: [
+          {
+            id: 'memory-old',
+            sessionId: 'session-1',
+            kind: 'request',
+            content: 'Old request',
+            createdAt: expiredDate
+          },
+          {
+            id: 'memory-new',
+            sessionId: 'session-1',
+            kind: 'request',
+            content: 'Fresh request',
+            createdAt: recentDate
+          }
+        ],
+        scopedItems: [
+          [
+            `${scopePrefix}old`,
+            {
+              key: 'old',
+              value: 'Expired context',
+              createdAt: expiredDate
+            }
+          ],
+          [
+            `${scopePrefix}newer`,
+            {
+              key: 'newer',
+              value: 'Fresh context',
+              createdAt: recentDate
+            }
+          ],
+          [
+            `${scopePrefix}newest`,
+            {
+              key: 'newest',
+              value: 'Freshest context',
+              createdAt: new Date(Date.now() + 1000).toISOString()
+            }
+          ]
+        ]
+      }),
+      'utf8'
+    );
+
+    const store = new FileBackedGomiMemoryStore(filePath);
+    const report = store.prune(scope, {
+      retentionDays: 30,
+      maxProjectMemoryItems: 1
+    });
+
+    expect(report).toEqual({
+      removed: 3,
+      remaining: 2
+    });
+  });
+
   it('prunes vector memory by scope retention and max project items', async () => {
     const filePath = path.join(tempDirectory, 'vector-memory.json');
     const scope: GomiMemoryScope = { workspaceId: 'Gomi' };


### PR DESCRIPTION
## Summary
- Adds a manual `Prune Now` action to the Office Settings memory controls.
- Returns a removal report with total, lexical, and vector memory counts after retention pruning.
- Wires the action through the browser demo runtime and native webview/workbench bridge.

## Linked issues / bounty
- Fixes https://github.com/mergeos-bounties/Gomi/issues/48
- Refs https://github.com/mergeos-bounties/mergeos/issues/244
- Gomi issue plan/comment: https://github.com/mergeos-bounties/Gomi/issues/48#issuecomment-4951971680
- MergeOS claim-token tracking comment: https://github.com/mergeos-bounties/mergeos/issues/1#issuecomment-4951971731
- MergeOS job tracking comment: https://github.com/mergeos-bounties/mergeos/issues/244#issuecomment-4951971806

## Problem
The memory retention policy pruned automatically, but users did not have an explicit Office Settings action to trigger pruning or see how many lexical/vector records were removed and retained.

## Fix
- Makes lexical and vector memory stores return prune reports.
- Adds `GomiAgentRuntime.pruneMemory()` aggregation for lexical and vector stores.
- Adds `gomi.pruneMemory` / `gomi.pruneMemoryResult` bridge messages in browser and workbench controllers.
- Shows `Prune Now`, loading/error state, and removed/remaining count chips in the memory settings UI.
- Extends unit coverage for store reports, runtime pruning, bridge handling, and workbench controller handling.

## Verification
QA approved commit `3826998ec7a9afed194f0c9d5a946c9b46339bd7` with:

```bash
npm ci
npm test -- tests/persistentProjectMemory.test.ts tests/agentRuntime.test.ts tests/gomiWebviewHostController.test.ts tests/gomiWorkbenchController.test.ts
npm run typecheck
npm test
npm run build
```

QA result summary:
- Targeted tests passed: 4 files, 34 tests.
- Full suite passed: 26 files passed, 1 skipped; 124 tests passed, 3 skipped.
- Typecheck passed.
- Build passed.
- UI evidence captured for `Prune Now` with `0 removed`, `0 remaining`, `lexical 0/0`, and `vector 0/0`; embedded below.

UI screenshot evidence (`BOU-4291-gomi-prune-now.png`, SHA-256 `f586130a0adc8f94632b5a2a772ce2e763f71878725999b9cacb35fdc910c946`):

![Gomi Office Prune Now evidence](https://raw.githubusercontent.com/Rajesh270712/Gomi/bountyops/gomi-48-evidence/docs/images/gomi-prune-now-evidence.png)

Evidence file: https://github.com/Rajesh270712/Gomi/blob/bountyops/gomi-48-evidence/docs/images/gomi-prune-now-evidence.png

Maintainer preflight also passed:

```bash
git diff --check origin/master...HEAD
```

Notes:
- `npm ci` reported the existing 11 high severity npm audit warnings.
- `npm run build` reported the existing Vite large chunk warning.
- This package does not expose `format:check` or `lint` scripts, so those MergeOS umbrella commands were not runnable as named here.

## Risk notes
- The change is scoped to Gomi memory pruning/reporting and bridge messages.
- Reverting this PR removes the manual prune UI and report plumbing while leaving the existing automatic retention behavior path intact.