### PR TITLE
Harden Gomi patch path containment

### DIFF
--- a/src/vs/workbench/contrib/gomi/node/workspacePatchApplier.ts
+++ b/src/vs/workbench/contrib/gomi/node/workspacePatchApplier.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import type { GomiPatchProposal } from '../common/gomiTypes';
-import { applyParsedPatchFile, parseUnifiedDiff } from './patchApplier';
+import { applyParsedPatchFile, parseUnifiedDiff, type ParsedPatchFile } from './patchApplier';
 
 export interface GomiPatchApplyOptions {
   dryRun?: boolean;
@@ -16,6 +16,13 @@ export interface GomiPatchApplyResult {
   deletedFiles: string[];
 }
 
+interface PreparedWorkspacePatchFile {
+  parsedFile: ParsedPatchFile;
+  targetAbsolutePath: string;
+  oldAbsolutePath?: string;
+  newAbsolutePath?: string;
+}
+
 export async function applyPatchProposalToWorkspace(
   patch: GomiPatchProposal,
   workspaceRoot: string,
@@ -28,35 +35,33 @@ export async function applyPatchProposalToWorkspace(
   }
 
   const parsedFiles = parseUnifiedDiff(patch.diff);
+  const preparedFiles = await Promise.all(
+    parsedFiles.map((parsedFile) => prepareWorkspacePatchFile(workspaceRoot, parsedFile))
+  );
   const appliedFiles: string[] = [];
   const deletedFiles: string[] = [];
 
-  for (const parsedFile of parsedFiles) {
-    const targetPath = parsedFile.newPath ?? parsedFile.oldPath;
-
-    if (!targetPath) {
-      throw new Error('Patch file is missing both old and new paths.');
-    }
-
-    const absolutePath = await resolveWorkspacePatchPathSafe(workspaceRoot, targetPath);
-    const existingContent = await readTextFileIfExists(absolutePath);
+  for (const { parsedFile, targetAbsolutePath, oldAbsolutePath, newAbsolutePath } of preparedFiles) {
+    const existingContent = await readTextFileIfExists(targetAbsolutePath);
     const nextContent = applyParsedPatchFile(existingContent, parsedFile);
 
     if (parsedFile.newPath === undefined) {
-      deletedFiles.push(toPortableRelativePath(workspaceRoot, absolutePath));
+      deletedFiles.push(toPortableRelativePath(workspaceRoot, targetAbsolutePath));
 
       if (!options.dryRun) {
-        await fs.rm(absolutePath, { force: true });
+        await fs.rm(targetAbsolutePath, { force: true });
       }
 
       continue;
     }
 
-    appliedFiles.push(toPortableRelativePath(workspaceRoot, absolutePath));
+    const writeAbsolutePath = newAbsolutePath ?? targetAbsolutePath;
+
+    appliedFiles.push(toPortableRelativePath(workspaceRoot, writeAbsolutePath));
 
     if (!options.dryRun) {
-      await fs.mkdir(path.dirname(absolutePath), { recursive: true });
-      await fs.writeFile(absolutePath, nextContent, 'utf8');
+      await fs.mkdir(path.dirname(writeAbsolutePath), { recursive: true });
+      await fs.writeFile(writeAbsolutePath, nextContent, 'utf8');
     }
 
     const isRename =
@@ -64,8 +69,7 @@ export async function applyPatchProposalToWorkspace(
       parsedFile.newPath !== undefined &&
       parsedFile.oldPath !== parsedFile.newPath;
 
-    if (isRename && parsedFile.oldPath) {
-      const oldAbsolutePath = await resolveWorkspacePatchPathSafe(workspaceRoot, parsedFile.oldPath);
+    if (isRename && oldAbsolutePath) {
       deletedFiles.push(toPortableRelativePath(workspaceRoot, oldAbsolutePath));
 
       if (!options.dryRun) {
@@ -82,17 +86,43 @@ export async function applyPatchProposalToWorkspace(
   };
 }
 
+async function prepareWorkspacePatchFile(
+  workspaceRoot: string,
+  parsedFile: ParsedPatchFile
+): Promise<PreparedWorkspacePatchFile> {
+  const oldAbsolutePath =
+    parsedFile.oldPath === undefined
+      ? undefined
+      : await resolveWorkspacePatchPathSafe(workspaceRoot, parsedFile.oldPath);
+  const newAbsolutePath =
+    parsedFile.newPath === undefined
+      ? undefined
+      : await resolveWorkspacePatchPathSafe(workspaceRoot, parsedFile.newPath);
+  const targetAbsolutePath = newAbsolutePath ?? oldAbsolutePath;
+
+  if (!targetAbsolutePath) {
+    throw new Error('Patch file is missing both old and new paths.');
+  }
+
+  return {
+    parsedFile,
+    targetAbsolutePath,
+    oldAbsolutePath,
+    newAbsolutePath
+  };
+}
+
 async function resolveWorkspacePatchPathSafe(workspaceRoot: string, patchPath: string): Promise<string> {
-  if (path.isAbsolute(patchPath)) {
+  if (isAbsolutePatchPath(patchPath)) {
     throw new Error(`Patch path must be relative to the workspace: ${patchPath}`);
   }
 
-  const normalizedPatchPath = patchPath.split('/').join(path.sep);
+  const normalizedPatchPath = patchPath.split(/[\\/]/).join(path.sep);
   const root = path.resolve(workspaceRoot);
   const absolutePath = path.resolve(root, normalizedPatchPath);
   const relativePath = path.relative(root, absolutePath);
 
-  if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+  if (isOutsideWorkspaceRelativePath(relativePath)) {
     throw new Error(`Patch path escapes the workspace root: ${patchPath}`);
   }
 
@@ -102,12 +132,20 @@ async function resolveWorkspacePatchPathSafe(workspaceRoot: string, patchPath: s
     const realRoot = await fs.realpath(root).catch(() => root);
     const realRelative = path.relative(realRoot, realAncestor);
 
-    if (realRelative.startsWith('..') || path.isAbsolute(realRelative)) {
+    if (isOutsideWorkspaceRelativePath(realRelative)) {
       throw new Error(`Patch path resolves outside the workspace root through a symlink: ${patchPath}`);
     }
   }
 
   return absolutePath;
+}
+
+function isAbsolutePatchPath(patchPath: string): boolean {
+  return path.isAbsolute(patchPath) || /^[A-Za-z]:[\\/]/.test(patchPath) || /^\\\\/.test(patchPath);
+}
+
+function isOutsideWorkspaceRelativePath(relativePath: string): boolean {
+  return relativePath === '..' || relativePath.startsWith(`..${path.sep}`) || path.isAbsolute(relativePath);
 }
 
 async function realPathOfNearestAncestor(absolutePath: string): Promise<string | undefined> {

--- a/tests/patchApplier.test.ts
+++ b/tests/patchApplier.test.ts
@@ -97,6 +97,27 @@ describe('patchApplier', () => {
     expect(content).toContain('# Gomi Plan');
   });
 
+  it('accepts nested valid patch paths', async () => {
+    const result = await applyPatchProposalToWorkspace(
+      createPatch({
+        diff: [
+          'diff --git a/packages/gomi/src/feature.ts b/packages/gomi/src/feature.ts',
+          'new file mode 100644',
+          '--- /dev/null',
+          '+++ b/packages/gomi/src/feature.ts',
+          '@@ -0,0 +1 @@',
+          '+export const enabled = true;'
+        ].join('\n')
+      }),
+      workspaceRoot
+    );
+
+    const content = await fs.readFile(path.join(workspaceRoot, 'packages', 'gomi', 'src', 'feature.ts'), 'utf8');
+
+    expect(result.appliedFiles).toEqual(['packages/gomi/src/feature.ts']);
+    expect(content).toContain('export const enabled = true;');
+  });
+
   it('rejects unapproved patches and paths outside the workspace', async () => {
     await expect(
       applyPatchProposalToWorkspace(
@@ -128,6 +149,78 @@ describe('patchApplier', () => {
         workspaceRoot
       )
     ).rejects.toThrow('escapes the workspace root');
+  });
+
+  it('rejects absolute patch paths', async () => {
+    const absolutePath = path.join(os.tmpdir(), 'gomi-outside.txt');
+
+    await expect(
+      applyPatchProposalToWorkspace(
+        createPatch({
+          diff: [
+            `diff --git a/src/app.ts ${absolutePath}`,
+            '--- /dev/null',
+            `+++ ${absolutePath}`,
+            '@@ -0,0 +1 @@',
+            '+escape'
+          ].join('\n')
+        }),
+        workspaceRoot
+      )
+    ).rejects.toThrow('Patch path must be relative to the workspace');
+  });
+
+  it('rejects Windows absolute patch paths on every platform', async () => {
+    await expect(
+      applyPatchProposalToWorkspace(
+        createPatch({
+          diff: [
+            'diff --git a/src/app.ts b/C:/Users/agent/outside.txt',
+            '--- /dev/null',
+            '+++ b/C:/Users/agent/outside.txt',
+            '@@ -0,0 +1 @@',
+            '+escape'
+          ].join('\n')
+        }),
+        workspaceRoot
+      )
+    ).rejects.toThrow('Patch path must be relative to the workspace');
+  });
+
+  it('rejects a multi-file patch all-or-nothing when one path escapes the workspace', async () => {
+    await fs.mkdir(path.join(workspaceRoot, 'src'), { recursive: true });
+    await fs.writeFile(
+      path.join(workspaceRoot, 'src', 'app.ts'),
+      'export const name = "Gomi";\nexport const mode = "demo";\n',
+      'utf8'
+    );
+
+    await expect(
+      applyPatchProposalToWorkspace(
+        createPatch({
+          diff: [
+            'diff --git a/src/app.ts b/src/app.ts',
+            '--- a/src/app.ts',
+            '+++ b/src/app.ts',
+            '@@ -1,2 +1,2 @@',
+            ' export const name = "Gomi";',
+            '-export const mode = "demo";',
+            '+export const mode = "office";',
+            'diff --git a/../outside.txt b/../outside.txt',
+            'new file mode 100644',
+            '--- /dev/null',
+            '+++ b/../outside.txt',
+            '@@ -0,0 +1 @@',
+            '+escape'
+          ].join('\n')
+        }),
+        workspaceRoot
+      )
+    ).rejects.toThrow('escapes the workspace root');
+
+    await expect(fs.readFile(path.join(workspaceRoot, 'src', 'app.ts'), 'utf8')).resolves.toContain(
+      'export const mode = "demo";'
+    );
   });
 });
 


### PR DESCRIPTION
## Summary

- Reject approved patch targets that resolve outside the workspace before any file writes occur.
- Cover traversal, POSIX absolute path, Windows drive absolute path, nested valid path, and multi-file one-bad-path behavior.
- Preserve the existing approval-before-apply gate.

## Linked issue

Refs #3.

## Problem

Unified diff file paths need to be contained to the workspace before applying a patch. Without validating every target path up front, a bad path can escape containment or leave earlier valid files written before the invalid path is rejected.

## Fix

- Resolve each parsed diff file path before any write.
- Reject POSIX absolute paths, Windows drive absolute paths, UNC-style absolute paths, traversal escapes, and symlink ancestor escapes.
- Apply writes only after all files in the patch pass containment validation.

## Validation

Passed in QA:

- `npm ci`
- `npm test -- tests/patchApplier.test.ts tests/patchApproval.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run verify:release`
- `npm run build`
- `npm run build:webview`
- `git diff --check master..HEAD`

## Risk and maintainer notes

- Low risk, TypeScript-only change scoped to `src/vs/workbench/contrib/gomi/node/workspacePatchApplier.ts` and `tests/patchApplier.test.ts`.
- `requireApproval` still defaults to `true`, and unapproved patches are still rejected before parsing or writing.
- No package, lockfile, generated, or unrelated formatting changes.
