### PR TITLE
Validate Gomi webview bridge messages

### DIFF
--- a/src/vs/workbench/contrib/gomi/browser/gomiWebviewBridge.ts
+++ b/src/vs/workbench/contrib/gomi/browser/gomiWebviewBridge.ts
@@ -1,4 +1,22 @@
-import type { GomiBridgeMessage, GomiWorkbenchBridge } from '../electron-sandbox/gomiBridge';
+import type {
+  GomiAgentCliProviderId,
+  GomiAgentId,
+  GomiAgentSeat,
+  GomiAgentSeatKind,
+  GomiAgentWorkMode,
+  GomiLiveProviderMode,
+  GomiMemoryEmbeddingProviderId,
+  GomiMemoryPrivacyMode,
+  GomiPatchApprovalStatus,
+  GomiPatchProposal,
+  GomiPatchRiskLevel,
+  GomiWorkspaceTrustState
+} from '../common/gomiTypes';
+import {
+  GOMI_BRIDGE_PROTOCOL_VERSION,
+  type GomiBridgeMessage,
+  type GomiWorkbenchBridge
+} from '../electron-sandbox/gomiBridge';
 
 export interface GomiVsCodeWebviewApi {
   postMessage(message: GomiBridgeMessage): void;
@@ -57,7 +75,7 @@ export function createGomiWebviewBridge(
 ): GomiWorkbenchBridge {
   return {
     postMessage(message) {
-      api.postMessage(message);
+      api.postMessage(withGomiBridgeProtocol(message));
     },
 
     onMessage(listener) {
@@ -93,6 +111,62 @@ export function createGomiWebviewStateStore(api: GomiVsCodeWebviewApi): GomiWebv
 
 const trustedGomiOriginPrefixes = ['vscode-webview://', 'vscode-file://'];
 
+// Bridge messages cross the webview/host privilege boundary; every new type must
+// be added here with an explicit protocol and payload schema before dispatch.
+export const GOMI_BRIDGE_MAX_MESSAGE_BYTES = 64_000;
+
+const GOMI_BRIDGE_MAX_TEXT_LENGTH = 16_000;
+const GOMI_BRIDGE_MAX_ERROR_LENGTH = 2_000;
+const GOMI_BRIDGE_MAX_PATCH_DIFF_LENGTH = 60_000;
+const GOMI_BRIDGE_MAX_PATH_LENGTH = 500;
+const GOMI_BRIDGE_MAX_ARRAY_ITEMS = 100;
+
+const GOMI_AGENT_IDS: readonly GomiAgentId[] = [
+  'ceo',
+  'system-analyst',
+  'backend',
+  'frontend',
+  'designer',
+  'database',
+  'qa',
+  'devops'
+];
+const GOMI_AGENT_PROVIDER_IDS: readonly GomiAgentCliProviderId[] = [
+  'codex-cli',
+  'claude-code',
+  'gemini-cli',
+  'aider-cli',
+  'cursor-style-agent',
+  'openai-compatible-api',
+  'ollama-local-model',
+  'local-llm',
+  'demo-runtime'
+];
+const GOMI_SEAT_KINDS: readonly GomiAgentSeatKind[] = ['executive', 'department-head', 'employee'];
+const GOMI_AGENT_WORK_MODES: readonly GomiAgentWorkMode[] = ['active', 'sleeping', 'fired'];
+const GOMI_MEMORY_EMBEDDING_PROVIDERS: readonly GomiMemoryEmbeddingProviderId[] = [
+  'local-hashing',
+  'openai-compatible',
+  'ollama-embeddings',
+  'ollama-embed'
+];
+const GOMI_MEMORY_PRIVACY_MODES: readonly GomiMemoryPrivacyMode[] = ['standard', 'strict'];
+const GOMI_WORKSPACE_TRUST_STATES: readonly GomiWorkspaceTrustState[] = ['trusted', 'untrusted'];
+const GOMI_LIVE_PROVIDER_MODES: readonly GomiLiveProviderMode[] = [
+  'demo-only',
+  'trusted-workspaces',
+  'allow-all'
+];
+const GOMI_PATCH_APPROVAL_STATUSES: readonly GomiPatchApprovalStatus[] = [
+  'pending',
+  'approved',
+  'rejected',
+  'applying',
+  'applied',
+  'failed'
+];
+const GOMI_PATCH_RISK_LEVELS: readonly GomiPatchRiskLevel[] = ['low', 'medium', 'high'];
+
 export function isTrustedGomiMessageEvent(event: Pick<MessageEvent, 'origin' | 'source'>): boolean {
   const origin = event.origin;
 
@@ -111,11 +185,281 @@ export function isTrustedGomiMessageEvent(event: Pick<MessageEvent, 'origin' | '
 }
 
 export function isGomiBridgeMessage(value: unknown): value is GomiBridgeMessage {
+  if (!isRecord(value) || value.protocolVersion !== GOMI_BRIDGE_PROTOCOL_VERSION) {
+    return false;
+  }
+
+  if (getSerializedMessageSize(value) > GOMI_BRIDGE_MAX_MESSAGE_BYTES) {
+    return false;
+  }
+
+  switch (value.type) {
+    case 'gomi.run':
+      return (
+        hasOnlyKeys(value, ['protocolVersion', 'type', 'request', 'officeSettings']) &&
+        isSafeString(value.request, GOMI_BRIDGE_MAX_TEXT_LENGTH) &&
+        isOptionalOfficeSettings(value.officeSettings)
+      );
+    case 'gomi.stop':
+      return (
+        hasOnlyKeys(value, ['protocolVersion', 'type', 'reason']) &&
+        isOptionalSafeString(value.reason, GOMI_BRIDGE_MAX_ERROR_LENGTH)
+      );
+    case 'gomi.pruneMemory':
+      return (
+        hasOnlyKeys(value, ['protocolVersion', 'type', 'officeSettings']) &&
+        isOptionalOfficeSettings(value.officeSettings)
+      );
+    case 'gomi.applyPatch':
+    case 'gomi.previewPatch':
+      return hasOnlyKeys(value, ['protocolVersion', 'type', 'patch']) && isPatchProposal(value.patch);
+    case 'gomi.applyPatchResult':
+    case 'gomi.previewPatchResult':
+      return (
+        hasOnlyKeys(value, ['protocolVersion', 'type', 'patchId', 'result', 'error']) &&
+        isSafeString(value.patchId, 128) &&
+        (value.result === undefined || isRecord(value.result)) &&
+        isOptionalSafeString(value.error, GOMI_BRIDGE_MAX_ERROR_LENGTH)
+      );
+    case 'gomi.pruneMemoryResult':
+      return (
+        hasOnlyKeys(value, ['protocolVersion', 'type', 'report', 'error']) &&
+        (value.report === undefined || isRecord(value.report)) &&
+        isOptionalSafeString(value.error, GOMI_BRIDGE_MAX_ERROR_LENGTH)
+      );
+    case 'gomi.event':
+      return hasOnlyKeys(value, ['protocolVersion', 'type', 'event']) && isRecord(value.event);
+    case 'gomi.bridgeError':
+      return (
+        hasOnlyKeys(value, ['protocolVersion', 'type', 'code', 'message']) &&
+        value.code === 'invalid_message' &&
+        isSafeString(value.message, GOMI_BRIDGE_MAX_ERROR_LENGTH)
+      );
+    default:
+      return false;
+  }
+}
+
+export function withGomiBridgeProtocol(message: GomiBridgeMessage): GomiBridgeMessage {
+  return {
+    ...message,
+    protocolVersion: GOMI_BRIDGE_PROTOCOL_VERSION
+  };
+}
+
+export function createGomiBridgeErrorMessage(): GomiBridgeMessage {
+  return {
+    protocolVersion: GOMI_BRIDGE_PROTOCOL_VERSION,
+    type: 'gomi.bridgeError',
+    code: 'invalid_message',
+    message: 'Rejected invalid Gomi bridge message.'
+  };
+}
+
+export function shouldReportInvalidGomiBridgeMessage(value: unknown): boolean {
   return (
-    typeof value === 'object' &&
-    value !== null &&
-    'type' in value &&
-    typeof value.type === 'string' &&
-    value.type.startsWith('gomi.')
+    isRecord(value) &&
+    (value.protocolVersion !== undefined ||
+      (typeof value.type === 'string' && value.type.startsWith('gomi.')))
   );
+}
+
+function getSerializedMessageSize(value: unknown): number {
+  try {
+    return new TextEncoder().encode(JSON.stringify(value)).byteLength;
+  } catch {
+    return Number.POSITIVE_INFINITY;
+  }
+}
+
+function isPatchProposal(value: unknown): value is GomiPatchProposal {
+  if (
+    !isRecord(value) ||
+    !hasOnlyKeys(value, [
+      'id',
+      'filePath',
+      'targetFiles',
+      'summary',
+      'diff',
+      'approvalStatus',
+      'riskLevel',
+      'createdByAgentId'
+    ])
+  ) {
+    return false;
+  }
+
+  return (
+    isSafeString(value.id, 128) &&
+    isSafeRelativePath(value.filePath) &&
+    isSafeStringArray(value.targetFiles, GOMI_BRIDGE_MAX_ARRAY_ITEMS, isSafeRelativePath) &&
+    isSafeString(value.summary, 2_000) &&
+    isSafeString(value.diff, GOMI_BRIDGE_MAX_PATCH_DIFF_LENGTH) &&
+    isOneOf(value.approvalStatus, GOMI_PATCH_APPROVAL_STATUSES) &&
+    isOneOf(value.riskLevel, GOMI_PATCH_RISK_LEVELS) &&
+    isOneOf(value.createdByAgentId, GOMI_AGENT_IDS)
+  );
+}
+
+function isOptionalOfficeSettings(value: unknown): boolean {
+  if (value === undefined) {
+    return true;
+  }
+
+  if (!isRecord(value) || !hasOnlyKeys(value, ['seats', 'memory', 'execution'])) {
+    return false;
+  }
+
+  return isSeatArray(value.seats) && isMemorySettings(value.memory) && isExecutionSettings(value.execution);
+}
+
+function isSeatArray(value: unknown): value is GomiAgentSeat[] {
+  return Array.isArray(value) && value.length <= 64 && value.every(isSeat);
+}
+
+function isSeat(value: unknown): value is GomiAgentSeat {
+  if (
+    !isRecord(value) ||
+    !hasOnlyKeys(value, [
+      'id',
+      'agentId',
+      'name',
+      'role',
+      'seatKind',
+      'providerId',
+      'workMode',
+      'canSleep',
+      'canFire',
+      'departmentId'
+    ])
+  ) {
+    return false;
+  }
+
+  return (
+    isSafeString(value.id, 128) &&
+    isOneOf(value.agentId, GOMI_AGENT_IDS) &&
+    isSafeString(value.name, 128) &&
+    isSafeString(value.role, 256) &&
+    isOneOf(value.seatKind, GOMI_SEAT_KINDS) &&
+    isOneOf(value.providerId, GOMI_AGENT_PROVIDER_IDS) &&
+    isOneOf(value.workMode, GOMI_AGENT_WORK_MODES) &&
+    typeof value.canSleep === 'boolean' &&
+    typeof value.canFire === 'boolean' &&
+    (value.departmentId === undefined || isOneOf(value.departmentId, GOMI_AGENT_IDS))
+  );
+}
+
+function isMemorySettings(value: unknown): boolean {
+  if (
+    !isRecord(value) ||
+    !hasOnlyKeys(value, [
+      'retrievalMode',
+      'embeddingProvider',
+      'embeddingExecutionEnabled',
+      'sharedMemoryEnabled',
+      'indexWorkspaceContext',
+      'privacyMode',
+      'redactSecrets',
+      'retentionDays',
+      'maxProjectMemoryItems',
+      'broadcastThreshold',
+      'requirePatchApproval'
+    ])
+  ) {
+    return false;
+  }
+
+  return (
+    value.retrievalMode === 'hybrid-vector' &&
+    isOneOf(value.embeddingProvider, GOMI_MEMORY_EMBEDDING_PROVIDERS) &&
+    typeof value.embeddingExecutionEnabled === 'boolean' &&
+    typeof value.sharedMemoryEnabled === 'boolean' &&
+    typeof value.indexWorkspaceContext === 'boolean' &&
+    isOneOf(value.privacyMode, GOMI_MEMORY_PRIVACY_MODES) &&
+    typeof value.redactSecrets === 'boolean' &&
+    isNumberInRange(value.retentionDays, 1, 3650) &&
+    isNumberInRange(value.maxProjectMemoryItems, 1, 10_000) &&
+    isNumberInRange(value.broadcastThreshold, 0, 1) &&
+    typeof value.requirePatchApproval === 'boolean'
+  );
+}
+
+function isExecutionSettings(value: unknown): boolean {
+  if (
+    !isRecord(value) ||
+    !hasOnlyKeys(value, [
+      'workspaceTrust',
+      'liveProviderMode',
+      'allowCliProviders',
+      'allowHttpProviders',
+      'requirePatchApprovalForLiveProviders',
+      'maxConcurrentAgentRuns'
+    ])
+  ) {
+    return false;
+  }
+
+  return (
+    isOneOf(value.workspaceTrust, GOMI_WORKSPACE_TRUST_STATES) &&
+    isOneOf(value.liveProviderMode, GOMI_LIVE_PROVIDER_MODES) &&
+    typeof value.allowCliProviders === 'boolean' &&
+    typeof value.allowHttpProviders === 'boolean' &&
+    typeof value.requirePatchApprovalForLiveProviders === 'boolean' &&
+    isNumberInRange(value.maxConcurrentAgentRuns, 1, 16)
+  );
+}
+
+function isSafeStringArray(
+  value: unknown,
+  maxItems: number,
+  itemValidator: (item: unknown) => boolean
+): value is string[] {
+  return Array.isArray(value) && value.length <= maxItems && value.every(itemValidator);
+}
+
+function isSafeString(value: unknown, maxLength: number): value is string {
+  return typeof value === 'string' && value.length > 0 && value.length <= maxLength;
+}
+
+function isOptionalSafeString(value: unknown, maxLength: number): value is string | undefined {
+  return value === undefined || (typeof value === 'string' && value.length <= maxLength);
+}
+
+function isSafeRelativePath(value: unknown): value is string {
+  if (!isSafeString(value, GOMI_BRIDGE_MAX_PATH_LENGTH)) {
+    return false;
+  }
+
+  const normalized = value.replace(/\\/g, '/');
+
+  if (normalized.startsWith('/') || normalized.includes('\0')) {
+    return false;
+  }
+
+  return normalized.split('/').every((segment) => segment.length > 0 && segment !== '.' && segment !== '..');
+}
+
+function isNumberInRange(value: unknown, min: number, max: number): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= min && value <= max;
+}
+
+function isOneOf<T extends string>(value: unknown, allowed: readonly T[]): value is T {
+  return typeof value === 'string' && allowed.includes(value as T);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasOnlyKeys(value: Record<string, unknown>, allowedKeys: readonly string[]): boolean {
+  const allowed = new Set(allowedKeys);
+
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key) || key === '__proto__' || key === 'prototype' || key === 'constructor') {
+      return false;
+    }
+  }
+
+  return true;
 }

--- a/src/vs/workbench/contrib/gomi/browser/gomiWebviewHostBridge.ts
+++ b/src/vs/workbench/contrib/gomi/browser/gomiWebviewHostBridge.ts
@@ -1,5 +1,10 @@
 import type { GomiBridgeMessage, GomiWorkbenchBridge } from '../electron-sandbox/gomiBridge';
-import { isGomiBridgeMessage } from './gomiWebviewBridge';
+import {
+  createGomiBridgeErrorMessage,
+  isGomiBridgeMessage,
+  shouldReportInvalidGomiBridgeMessage,
+  withGomiBridgeProtocol
+} from './gomiWebviewBridge';
 
 export interface GomiDisposable {
   dispose(): void;
@@ -21,6 +26,10 @@ export class GomiWebviewHostBridge implements GomiWorkbenchBridge, GomiDisposabl
   constructor(private readonly webview: GomiNativeWebviewHost) {
     this.disposable = this.webview.onMessage((event) => {
       if (!isGomiBridgeMessage(event.message)) {
+        if (shouldReportInvalidGomiBridgeMessage(event.message)) {
+          void this.webview.postMessage(createGomiBridgeErrorMessage());
+        }
+
         return;
       }
 
@@ -31,7 +40,7 @@ export class GomiWebviewHostBridge implements GomiWorkbenchBridge, GomiDisposabl
   }
 
   postMessage(message: GomiBridgeMessage): void {
-    void this.webview.postMessage(message);
+    void this.webview.postMessage(withGomiBridgeProtocol(message));
   }
 
   onMessage(listener: (message: GomiBridgeMessage) => void): () => void {

--- a/src/vs/workbench/contrib/gomi/electron-sandbox/gomiBridge.ts
+++ b/src/vs/workbench/contrib/gomi/electron-sandbox/gomiBridge.ts
@@ -7,7 +7,13 @@ import type {
 import type { GomiRuntimeMemoryPruneReport } from '../node/agentRuntime';
 import type { GomiPatchApplyResult } from '../node/workspacePatchApplier';
 
-export type GomiBridgeMessage =
+export const GOMI_BRIDGE_PROTOCOL_VERSION = 1;
+
+export type GomiBridgeProtocolVersion = typeof GOMI_BRIDGE_PROTOCOL_VERSION;
+
+export type GomiBridgeMessage = {
+  protocolVersion?: GomiBridgeProtocolVersion;
+} & (
   | {
       type: 'gomi.run';
       request: string;
@@ -49,7 +55,13 @@ export type GomiBridgeMessage =
       patchId: string;
       result?: GomiPatchApplyResult;
       error?: string;
-    };
+    }
+  | {
+      type: 'gomi.bridgeError';
+      code: 'invalid_message';
+      message: string;
+    }
+);
 
 export interface GomiWorkbenchBridge {
   postMessage(message: GomiBridgeMessage): void;

--- a/tests/gomiWebviewBridge.test.ts
+++ b/tests/gomiWebviewBridge.test.ts
@@ -48,6 +48,7 @@ describe('Gomi webview bridge', () => {
       reason: 'Stop bridge test'
     });
     target.emit({
+      protocolVersion: 1,
       type: 'gomi.applyPatchResult',
       patchId: 'patch-1',
       result: {
@@ -60,16 +61,19 @@ describe('Gomi webview bridge', () => {
     target.emit({ type: 'not-gomi' });
     unsubscribe?.();
     target.emit({
+      protocolVersion: 1,
       type: 'gomi.applyPatchResult',
       patchId: 'patch-2'
     });
 
     expect(api.outbox).toEqual([
       {
+        protocolVersion: 1,
         type: 'gomi.run',
         request: 'Review workspace'
       },
       {
+        protocolVersion: 1,
         type: 'gomi.stop',
         reason: 'Stop bridge test'
       }
@@ -101,6 +105,7 @@ describe('Gomi webview bridge', () => {
     expect(api.state).toEqual({ persisted: true });
     expect(context?.stateStore.getState()).toEqual({ persisted: true });
     expect(api.outbox[0]).toMatchObject({
+      protocolVersion: 1,
       type: 'gomi.run',
       request: 'Persisted bridge'
     });
@@ -120,9 +125,44 @@ describe('Gomi webview bridge', () => {
   });
 
   it('filters bridge messages by Gomi namespace', () => {
-    expect(isGomiBridgeMessage({ type: 'gomi.event' })).toBe(true);
-    expect(isGomiBridgeMessage({ type: 'workspace.event' })).toBe(false);
+    expect(isGomiBridgeMessage({ protocolVersion: 1, type: 'gomi.stop' })).toBe(true);
+    expect(isGomiBridgeMessage({ type: 'gomi.stop' })).toBe(false);
+    expect(isGomiBridgeMessage({ protocolVersion: 2, type: 'gomi.stop' })).toBe(false);
+    expect(isGomiBridgeMessage({ protocolVersion: 1, type: 'gomi.danger' })).toBe(false);
+    expect(isGomiBridgeMessage({ protocolVersion: 1, type: 'workspace.event' })).toBe(false);
     expect(isGomiBridgeMessage(undefined)).toBe(false);
+  });
+
+  it('rejects malformed or oversized privileged webview payloads', () => {
+    expect(isGomiBridgeMessage({
+      protocolVersion: 1,
+      type: 'gomi.run',
+      request: 'x'.repeat(70_000)
+    })).toBe(false);
+    expect(isGomiBridgeMessage({
+      protocolVersion: 1,
+      type: 'gomi.run',
+      request: 'Review workspace',
+      officeSettings: {
+        seats: 'not-an-array',
+        memory: {},
+        execution: {}
+      }
+    })).toBe(false);
+    expect(isGomiBridgeMessage({
+      protocolVersion: 1,
+      type: 'gomi.applyPatch',
+      patch: {
+        id: 'patch-escape',
+        filePath: '../secret.txt',
+        targetFiles: ['README.md'],
+        summary: 'Unsafe patch.',
+        diff: 'diff --git a/README.md b/README.md\n@@ -1 +1 @@\n-old\n+new',
+        approvalStatus: 'approved',
+        riskLevel: 'low',
+        createdByAgentId: 'ceo'
+      }
+    })).toBe(false);
   });
 
   it('can be constructed directly with an injected api and target', () => {
@@ -136,6 +176,7 @@ describe('Gomi webview bridge', () => {
     });
 
     expect(api.outbox[0]).toMatchObject({
+      protocolVersion: 1,
       type: 'gomi.run',
       request: 'Direct bridge'
     });

--- a/tests/gomiWebviewHostBridge.test.ts
+++ b/tests/gomiWebviewHostBridge.test.ts
@@ -18,24 +18,28 @@ describe('Gomi webview host bridge', () => {
       request: 'Host to webview'
     });
     webview.emit({
+      protocolVersion: 1,
       type: 'gomi.applyPatchResult',
       patchId: 'patch-1'
     });
     webview.emit({ type: 'not-gomi' });
     unsubscribe();
     webview.emit({
+      protocolVersion: 1,
       type: 'gomi.applyPatchResult',
       patchId: 'patch-2'
     });
 
     expect(webview.outbox).toEqual([
       {
+        protocolVersion: 1,
         type: 'gomi.run',
         request: 'Host to webview'
       }
     ]);
     expect(received).toEqual([
       {
+        protocolVersion: 1,
         type: 'gomi.applyPatchResult',
         patchId: 'patch-1'
       }
@@ -43,11 +47,79 @@ describe('Gomi webview host bridge', () => {
 
     bridge.dispose();
     webview.emit({
+      protocolVersion: 1,
       type: 'gomi.applyPatchResult',
       patchId: 'patch-3'
     });
 
     expect(received).toHaveLength(1);
+  });
+
+  it('rejects invalid inbound messages with a sanitized bridge error', () => {
+    const webview = new MemoryNativeWebview();
+    const bridge = createGomiWebviewHostBridge(webview);
+    const received: GomiBridgeMessage[] = [];
+    bridge.onMessage((message) => received.push(message));
+
+    webview.emit({ type: 'gomi.run', request: 'Missing protocol' });
+    webview.emit({
+      protocolVersion: 1,
+      type: 'gomi.run',
+      request: 'x'.repeat(70_000)
+    });
+    webview.emit({
+      protocolVersion: 1,
+      type: 'gomi.run',
+      request: 'Review workspace',
+      officeSettings: {
+        seats: 'not-an-array',
+        memory: {},
+        execution: {}
+      }
+    });
+    webview.emit({
+      protocolVersion: 1,
+      type: 'gomi.applyPatch',
+      patch: {
+        id: 'patch-escape',
+        filePath: '../secret.txt',
+        targetFiles: ['README.md'],
+        summary: 'Unsafe patch.',
+        diff: 'diff --git a/README.md b/README.md\n@@ -1 +1 @@\n-old\n+new',
+        approvalStatus: 'approved',
+        riskLevel: 'low',
+        createdByAgentId: 'ceo'
+      }
+    });
+
+    expect(received).toEqual([]);
+    expect(webview.outbox).toEqual([
+      {
+        protocolVersion: 1,
+        type: 'gomi.bridgeError',
+        code: 'invalid_message',
+        message: 'Rejected invalid Gomi bridge message.'
+      },
+      {
+        protocolVersion: 1,
+        type: 'gomi.bridgeError',
+        code: 'invalid_message',
+        message: 'Rejected invalid Gomi bridge message.'
+      },
+      {
+        protocolVersion: 1,
+        type: 'gomi.bridgeError',
+        code: 'invalid_message',
+        message: 'Rejected invalid Gomi bridge message.'
+      },
+      {
+        protocolVersion: 1,
+        type: 'gomi.bridgeError',
+        code: 'invalid_message',
+        message: 'Rejected invalid Gomi bridge message.'
+      }
+    ]);
+    expect(JSON.stringify(webview.outbox)).not.toContain('../secret');
   });
 });
 


### PR DESCRIPTION
## Summary

- Add protocol version 1 stamping for Gomi webview bridge messages.
- Validate inbound Gomi bridge payloads before listener dispatch with explicit schemas, bounded string checks, and a 64KB serialized message limit.
- Reject unsafe patch proposal targets and malformed office-settings payloads before privileged handling.
- Return a sanitized `gomi.bridgeError` for invalid Gomi-looking messages without echoing attacker-controlled content.

Refs #22.

## Validation

- `npm ci`
- `npx vitest run tests/gomiWebviewBridge.test.ts tests/gomiWebviewHostBridge.test.ts tests/gomiWebviewHostController.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm run verify:release`
- `git diff --check origin/master...HEAD`

## Notes

- This is local code/test hardening only; no live target testing or private security testing was performed.
- The repository did not expose `lint` or `format:check` scripts in `package.json`, so those gates were not available to run.
- Local verification used Node v26 while the README guidance referenced by QA says Node 22; the commands above still passed locally.
- `npm ci` reported existing audit findings and `npm run build` emitted the existing Vite large-chunk warning; this patch does not change dependencies or lockfiles.
