### PR TITLE
Gomi #31: Add opt-in terminal snippet indexing

### DIFF
--- a/src/vs/workbench/contrib/gomi/browser/GomiOfficeApp.tsx
+++ b/src/vs/workbench/contrib/gomi/browser/GomiOfficeApp.tsx
@@ -69,6 +69,7 @@ import {
   setSeatWorkMode,
   setSecretRedactionEnabled,
   setSharedMemoryEnabled,
+  setTerminalSnippetIndexing,
   simulateStaffingScenario,
   setWorkspaceTrustState,
   setWorkspaceContextIndexing
@@ -635,6 +636,12 @@ export function GomiOfficeApp() {
     );
   }
 
+  function updateTerminalSnippetIndexing(indexTerminalSnippets: boolean) {
+    setOfficeSettings((currentSettings) =>
+      setTerminalSnippetIndexing(currentSettings, indexTerminalSnippets)
+    );
+  }
+
   function updateMemoryEmbeddingProvider(embeddingProvider: GomiMemoryEmbeddingProviderId) {
     setOfficeSettings((currentSettings) =>
       setMemoryEmbeddingProvider(currentSettings, embeddingProvider)
@@ -911,6 +918,7 @@ export function GomiOfficeApp() {
           onBroadcastThresholdChange={updateBroadcastThreshold}
           onSharedMemoryEnabledChange={updateSharedMemoryEnabled}
           onWorkspaceContextIndexingChange={updateWorkspaceContextIndexing}
+          onTerminalSnippetIndexingChange={updateTerminalSnippetIndexing}
           onMemoryEmbeddingProviderChange={updateMemoryEmbeddingProvider}
           onMemoryEmbeddingExecutionEnabledChange={updateMemoryEmbeddingExecutionEnabled}
           onMemoryPrivacyModeChange={updateMemoryPrivacyMode}
@@ -1119,6 +1127,7 @@ function RightPanel({
   onBroadcastThresholdChange,
   onSharedMemoryEnabledChange,
   onWorkspaceContextIndexingChange,
+  onTerminalSnippetIndexingChange,
   onMemoryEmbeddingProviderChange,
   onMemoryEmbeddingExecutionEnabledChange,
   onMemoryPrivacyModeChange,
@@ -1156,6 +1165,7 @@ function RightPanel({
   onBroadcastThresholdChange: (broadcastThreshold: number) => void;
   onSharedMemoryEnabledChange: (sharedMemoryEnabled: boolean) => void;
   onWorkspaceContextIndexingChange: (indexWorkspaceContext: boolean) => void;
+  onTerminalSnippetIndexingChange: (indexTerminalSnippets: boolean) => void;
   onMemoryEmbeddingProviderChange: (embeddingProvider: GomiMemoryEmbeddingProviderId) => void;
   onMemoryEmbeddingExecutionEnabledChange: (embeddingExecutionEnabled: boolean) => void;
   onMemoryPrivacyModeChange: (privacyMode: GomiMemoryPrivacyMode) => void;
@@ -1227,6 +1237,7 @@ function RightPanel({
           onBroadcastThresholdChange={onBroadcastThresholdChange}
           onSharedMemoryEnabledChange={onSharedMemoryEnabledChange}
           onWorkspaceContextIndexingChange={onWorkspaceContextIndexingChange}
+          onTerminalSnippetIndexingChange={onTerminalSnippetIndexingChange}
           onMemoryEmbeddingProviderChange={onMemoryEmbeddingProviderChange}
           onMemoryEmbeddingExecutionEnabledChange={onMemoryEmbeddingExecutionEnabledChange}
           onMemoryPrivacyModeChange={onMemoryPrivacyModeChange}
@@ -1351,6 +1362,7 @@ function OfficeSettingsPanel({
   onBroadcastThresholdChange,
   onSharedMemoryEnabledChange,
   onWorkspaceContextIndexingChange,
+  onTerminalSnippetIndexingChange,
   onMemoryEmbeddingProviderChange,
   onMemoryEmbeddingExecutionEnabledChange,
   onMemoryPrivacyModeChange,
@@ -1384,6 +1396,7 @@ function OfficeSettingsPanel({
   onBroadcastThresholdChange: (broadcastThreshold: number) => void;
   onSharedMemoryEnabledChange: (sharedMemoryEnabled: boolean) => void;
   onWorkspaceContextIndexingChange: (indexWorkspaceContext: boolean) => void;
+  onTerminalSnippetIndexingChange: (indexTerminalSnippets: boolean) => void;
   onMemoryEmbeddingProviderChange: (embeddingProvider: GomiMemoryEmbeddingProviderId) => void;
   onMemoryEmbeddingExecutionEnabledChange: (embeddingExecutionEnabled: boolean) => void;
   onMemoryPrivacyModeChange: (privacyMode: GomiMemoryPrivacyMode) => void;
@@ -1582,6 +1595,7 @@ function OfficeSettingsPanel({
           <span>{getMemoryEmbeddingProviderLabel(officeSettings.memory.embeddingProvider)}</span>
           <span>{officeSettings.memory.embeddingExecutionEnabled ? 'embeddings on' : 'embeddings local'}</span>
           <span>{officeSettings.memory.sharedMemoryEnabled ? 'shared on' : 'shared off'}</span>
+          <span>{officeSettings.memory.indexTerminalSnippets ? 'terminal snippets on' : 'terminal snippets off'}</span>
           <span>{officeSettings.memory.privacyMode}</span>
           <span>{`broadcast >= ${Math.round(officeSettings.memory.broadcastThreshold * 100)}%`}</span>
           <span>{`${officeSettings.memory.retentionDays}d retention`}</span>
@@ -1616,6 +1630,15 @@ function OfficeSettingsPanel({
             disabled={!officeSettings.memory.sharedMemoryEnabled}
           />
           <span>Index workspace context</span>
+        </label>
+        <label className="gomi-toggle-field">
+          <input
+            type="checkbox"
+            checked={officeSettings.memory.indexTerminalSnippets}
+            onChange={(event) => onTerminalSnippetIndexingChange(event.target.checked)}
+            disabled={!officeSettings.memory.sharedMemoryEnabled || !officeSettings.memory.indexWorkspaceContext}
+          />
+          <span>Terminal snippets</span>
         </label>
         <label className="gomi-field">
           <span>Embedding Provider</span>

--- a/src/vs/workbench/contrib/gomi/browser/gomiWebviewBridge.ts
+++ b/src/vs/workbench/contrib/gomi/browser/gomiWebviewBridge.ts
@@ -389,6 +389,7 @@ function isMemorySettings(value: unknown): boolean {
       'embeddingExecutionEnabled',
       'sharedMemoryEnabled',
       'indexWorkspaceContext',
+      'indexTerminalSnippets',
       'privacyMode',
       'redactSecrets',
       'retentionDays',
@@ -406,6 +407,7 @@ function isMemorySettings(value: unknown): boolean {
     typeof value.embeddingExecutionEnabled === 'boolean' &&
     typeof value.sharedMemoryEnabled === 'boolean' &&
     typeof value.indexWorkspaceContext === 'boolean' &&
+    typeof value.indexTerminalSnippets === 'boolean' &&
     isOneOf(value.privacyMode, GOMI_MEMORY_PRIVACY_MODES) &&
     typeof value.redactSecrets === 'boolean' &&
     isNumberInRange(value.retentionDays, 1, 3650) &&

--- a/src/vs/workbench/contrib/gomi/common/gomiOfficeSettings.ts
+++ b/src/vs/workbench/contrib/gomi/common/gomiOfficeSettings.ts
@@ -214,6 +214,7 @@ export const DEFAULT_GOMI_OFFICE_SETTINGS: GomiOfficeSettings = {
     embeddingExecutionEnabled: false,
     sharedMemoryEnabled: true,
     indexWorkspaceContext: true,
+    indexTerminalSnippets: false,
     privacyMode: 'standard',
     redactSecrets: true,
     retentionDays: GOMI_DEFAULT_MEMORY_RETENTION_DAYS,
@@ -331,6 +332,15 @@ export function setWorkspaceContextIndexing(
 ): GomiOfficeSettings {
   return updateMemorySettings(settings, {
     indexWorkspaceContext
+  });
+}
+
+export function setTerminalSnippetIndexing(
+  settings: GomiOfficeSettings,
+  indexTerminalSnippets: boolean
+): GomiOfficeSettings {
+  return updateMemorySettings(settings, {
+    indexTerminalSnippets
   });
 }
 
@@ -559,6 +569,10 @@ export function normalizeGomiOfficeSettings(value: unknown): GomiOfficeSettings 
   normalizedSettings = setWorkspaceContextIndexing(
     normalizedSettings,
     booleanSetting(rawMemory.indexWorkspaceContext, DEFAULT_GOMI_OFFICE_SETTINGS.memory.indexWorkspaceContext)
+  );
+  normalizedSettings = setTerminalSnippetIndexing(
+    normalizedSettings,
+    booleanSetting(rawMemory.indexTerminalSnippets, DEFAULT_GOMI_OFFICE_SETTINGS.memory.indexTerminalSnippets)
   );
   normalizedSettings = setMemoryEmbeddingProvider(
     normalizedSettings,

--- a/src/vs/workbench/contrib/gomi/common/gomiTypes.ts
+++ b/src/vs/workbench/contrib/gomi/common/gomiTypes.ts
@@ -86,6 +86,7 @@ export interface GomiOfficeMemorySettings {
   embeddingExecutionEnabled: boolean;
   sharedMemoryEnabled: boolean;
   indexWorkspaceContext: boolean;
+  indexTerminalSnippets: boolean;
   privacyMode: GomiMemoryPrivacyMode;
   redactSecrets: boolean;
   retentionDays: number;

--- a/src/vs/workbench/contrib/gomi/node/memoryPrivacy.ts
+++ b/src/vs/workbench/contrib/gomi/node/memoryPrivacy.ts
@@ -15,6 +15,9 @@ export interface GomiMemoryPolicyResult {
   audit: GomiMemoryPrivacyAudit;
 }
 
+export const GOMI_MAX_INDEXED_TERMINAL_SNIPPETS = 3;
+export const GOMI_MAX_INDEXED_TERMINAL_SNIPPET_CHARS = 1200;
+
 const STRICT_ONLY_SOURCES = new Set<GomiWorkspaceContentSnippet['source']>([
   'terminal',
   'error_log'
@@ -42,17 +45,26 @@ export function applyWorkspaceMemoryPolicy(
   });
   const openEditors = workspace.openEditors.filter((filePath) => !isSensitivePath(filePath));
   const contentSnippets: GomiWorkspaceContentSnippet[] = [];
+  let indexedTerminalSnippetCount = 0;
 
   for (const snippet of workspace.contentSnippets ?? []) {
-    if (shouldDropSnippet(snippet, settings)) {
+    if (shouldDropSnippet(snippet, settings, indexedTerminalSnippetCount)) {
       audit.droppedSnippets.push(snippet.filePath);
       continue;
     }
 
-    const content = settings.redactSecrets ? redactSecrets(snippet.content) : snippet.content;
+    const redactedContent = settings.redactSecrets ? redactSecrets(snippet.content) : snippet.content;
+    const content =
+      snippet.source === 'terminal'
+        ? redactedContent.slice(0, GOMI_MAX_INDEXED_TERMINAL_SNIPPET_CHARS)
+        : redactedContent;
 
-    if (content !== snippet.content) {
+    if (redactedContent !== snippet.content) {
       audit.redactedSnippets.push(snippet.filePath);
+    }
+
+    if (snippet.source === 'terminal') {
+      indexedTerminalSnippetCount += 1;
     }
 
     contentSnippets.push({
@@ -110,10 +122,19 @@ export function redactSecrets(value: string): string {
 
 function shouldDropSnippet(
   snippet: GomiWorkspaceContentSnippet,
-  settings: GomiOfficeMemorySettings
+  settings: GomiOfficeMemorySettings,
+  indexedTerminalSnippetCount: number
 ): boolean {
   if (isSensitivePath(snippet.filePath)) {
     return true;
+  }
+
+  if (snippet.source === 'terminal') {
+    return (
+      !settings.indexTerminalSnippets ||
+      settings.privacyMode === 'strict' ||
+      indexedTerminalSnippetCount >= GOMI_MAX_INDEXED_TERMINAL_SNIPPETS
+    );
   }
 
   return settings.privacyMode === 'strict' && STRICT_ONLY_SOURCES.has(snippet.source);

--- a/tests/memoryPrivacy.test.ts
+++ b/tests/memoryPrivacy.test.ts
@@ -1,9 +1,15 @@
 import { describe, expect, it } from 'vitest';
-import { DEFAULT_GOMI_OFFICE_SETTINGS, setMemoryPrivacyMode } from '../src/vs/workbench/contrib/gomi/common/gomiOfficeSettings';
+import {
+  DEFAULT_GOMI_OFFICE_SETTINGS,
+  setMemoryPrivacyMode,
+  setTerminalSnippetIndexing
+} from '../src/vs/workbench/contrib/gomi/common/gomiOfficeSettings';
 import type { GomiWorkspaceSnapshot } from '../src/vs/workbench/contrib/gomi/common/gomiTypes';
 import {
   applyWorkspaceMemoryPolicy,
   createMemoryPrivacySummary,
+  GOMI_MAX_INDEXED_TERMINAL_SNIPPET_CHARS,
+  GOMI_MAX_INDEXED_TERMINAL_SNIPPETS,
   redactSecrets
 } from '../src/vs/workbench/contrib/gomi/node/memoryPrivacy';
 
@@ -62,6 +68,39 @@ describe('memory privacy policy', () => {
 
     expect(authSnippet?.content).toContain('[REDACTED]');
     expect(authSnippet?.content).not.toContain('super-secret-value');
+  });
+
+  it('keeps terminal snippets out of memory by default while preserving terminal summary', () => {
+    const result = applyWorkspaceMemoryPolicy(workspace, DEFAULT_GOMI_OFFICE_SETTINGS.memory);
+
+    expect(DEFAULT_GOMI_OFFICE_SETTINGS.memory.indexTerminalSnippets).toBe(false);
+    expect(result.workspace.terminalSummary).toBe('npm test');
+    expect(result.workspace.contentSnippets?.some((snippet) => snippet.source === 'terminal')).toBe(false);
+    expect(result.audit.droppedSnippets).toContain('Terminal: npm test');
+  });
+
+  it('indexes terminal snippets only when enabled, with redaction and caps', () => {
+    const terminalWorkspace: GomiWorkspaceSnapshot = {
+      ...workspace,
+      contentSnippets: Array.from({ length: GOMI_MAX_INDEXED_TERMINAL_SNIPPETS + 2 }, (_, index) => ({
+        filePath: `Terminal: run ${index + 1}`,
+        content:
+          index === 0
+            ? `Bearer abcdefghijklmnopqrstuvwxyz\n${'x'.repeat(GOMI_MAX_INDEXED_TERMINAL_SNIPPET_CHARS + 60)}`
+            : `npm run task-${index + 1}`,
+        language: 'text',
+        source: 'terminal' as const
+      }))
+    };
+    const settings = setTerminalSnippetIndexing(DEFAULT_GOMI_OFFICE_SETTINGS, true);
+    const result = applyWorkspaceMemoryPolicy(terminalWorkspace, settings.memory);
+    const terminalSnippets = result.workspace.contentSnippets?.filter((snippet) => snippet.source === 'terminal') ?? [];
+
+    expect(terminalSnippets).toHaveLength(GOMI_MAX_INDEXED_TERMINAL_SNIPPETS);
+    expect(terminalSnippets[0]?.content).toContain('Bearer [REDACTED]');
+    expect(terminalSnippets[0]?.content).not.toContain('abcdefghijklmnopqrstuvwxyz');
+    expect(terminalSnippets.every((snippet) => snippet.content.length <= GOMI_MAX_INDEXED_TERMINAL_SNIPPET_CHARS)).toBe(true);
+    expect(result.audit.droppedSnippets).toContain(`Terminal: run ${GOMI_MAX_INDEXED_TERMINAL_SNIPPETS + 1}`);
   });
 
   it('drops terminal and error log snippets in strict mode', () => {

--- a/tests/officeSettings.test.ts
+++ b/tests/officeSettings.test.ts
@@ -29,6 +29,7 @@ import {
   simulateStaffingScenario,
   setWorkspaceTrustState,
   setSharedMemoryEnabled,
+  setTerminalSnippetIndexing,
   setWorkspaceContextIndexing,
   setAvatarStyle
 } from '../src/vs/workbench/contrib/gomi/common/gomiOfficeSettings';
@@ -154,6 +155,8 @@ describe('Gomi office settings', () => {
     expect(quietSettings.memory.sharedMemoryEnabled).toBe(false);
     expect(quietSettings.memory.indexWorkspaceContext).toBe(false);
     expect(relaxedApproval.memory.requirePatchApproval).toBe(false);
+    expect(DEFAULT_GOMI_OFFICE_SETTINGS.memory.indexTerminalSnippets).toBe(false);
+    expect(setTerminalSnippetIndexing(DEFAULT_GOMI_OFFICE_SETTINGS, true).memory.indexTerminalSnippets).toBe(true);
   });
 
   it('updates embedding provider execution while keeping local hashing offline', () => {
@@ -242,7 +245,8 @@ describe('Gomi office settings', () => {
         maxProjectMemoryItems: 1,
         broadcastThreshold: 0.1,
         privacyMode: 'strict',
-        redactSecrets: false
+        redactSecrets: false,
+        indexTerminalSnippets: true
       },
       execution: {
         workspaceTrust: 'trusted',
@@ -272,6 +276,7 @@ describe('Gomi office settings', () => {
     expect(settings.memory.embeddingExecutionEnabled).toBe(true);
     expect(settings.memory.privacyMode).toBe('strict');
     expect(settings.memory.redactSecrets).toBe(true);
+    expect(settings.memory.indexTerminalSnippets).toBe(true);
     expect(settings.memory.retentionDays).toBe(365);
     expect(settings.memory.maxProjectMemoryItems).toBe(40);
     expect(settings.memory.broadcastThreshold).toBe(0.45);


### PR DESCRIPTION
## Summary
- Adds an opt-in office setting for including a short recent terminal-output snippet in project context.
- Carries the setting through the webview bridge and office settings model.
- Keeps terminal snippet indexing off unless the user enables it.

## Linked issue / bounty
- Fixes https://github.com/mergeos-bounties/Gomi/issues/31

## Problem
Project context indexing did not have a user-facing opt-in path for terminal output snippets, so terminal state could not be included under an explicit privacy control.

## Fix
- Adds `includeTerminalSnippet` to Gomi office settings and bridge payloads.
- Adds UI control text for the terminal snippet opt-in.
- Updates memory privacy handling so terminal snippet entries are filtered unless the opt-in is enabled.
- Extends memory privacy and office settings tests for the new setting.

## Verification
Validated by QA on commit `9b9f9a016e0024680f7135f5f570a5c92b7f304f` with:
- `npm test -- tests/projectContextIndexer.test.ts tests/memoryPrivacy.test.ts tests/officeSettings.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `git diff --check origin/master...HEAD`

QA reported 27 test files / 139 tests passing, with 3 skipped. The build passed with the existing Vite chunk-size warning. `npm ci` surfaced existing dependency deprecation/audit warnings, and full tests emitted the existing Node localStorage experimental warning.

## Risk and rollback
Risk is limited to the Gomi office settings and memory privacy filtering path. Reverting this PR removes the terminal snippet opt-in and restores the previous filtering behavior.

## Maintainer attention
The setting is intentionally opt-in for privacy. Please let me know if you prefer a different label or default placement in Office Settings.
