### PR TITLE
Add prompt template library for Gomi Office requests

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -364,7 +364,7 @@ button {
 
 .gomi-request {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 132px;
+  grid-template-columns: minmax(0, 1fr) minmax(220px, 260px);
   gap: 10px;
   padding: 12px;
   border-bottom: 1px solid #1f2937;
@@ -386,6 +386,61 @@ button {
 .gomi-request textarea:focus {
   border-color: #2dd4bf;
   box-shadow: 0 0 0 2px rgba(45, 212, 191, 0.16);
+}
+
+.gomi-request-sidebar,
+.gomi-template-tools {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+}
+
+.gomi-request-sidebar {
+  grid-template-rows: auto minmax(42px, 1fr);
+}
+
+.gomi-template-tools {
+  grid-template-rows: auto auto 34px;
+  border: 1px solid #1f2937;
+  border-radius: 6px;
+  background: #111827;
+  padding: 8px;
+}
+
+.gomi-template-field {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  color: #94a3b8;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.gomi-template-field select,
+.gomi-template-field input {
+  width: 100%;
+  min-width: 0;
+  border: 1px solid #334155;
+  border-radius: 6px;
+  outline: none;
+  background: #101826;
+  color: #f9fafb;
+  padding: 7px 8px;
+  font-size: 12px;
+}
+
+.gomi-template-field select:focus,
+.gomi-template-field input:focus {
+  border-color: #2dd4bf;
+  box-shadow: 0 0 0 2px rgba(45, 212, 191, 0.16);
+}
+
+.gomi-template-actions {
+  display: grid;
+  grid-template-columns: repeat(4, 34px);
+  justify-content: space-between;
+  gap: 6px;
 }
 
 .gomi-send {

--- a/src/vs/workbench/contrib/gomi/browser/GomiOfficeApp.tsx
+++ b/src/vs/workbench/contrib/gomi/browser/GomiOfficeApp.tsx
@@ -3,6 +3,7 @@ import {
   Bot,
   Braces,
   CheckCircle2,
+  ClipboardPaste,
   ClipboardList,
   Code2,
   Database,
@@ -23,8 +24,10 @@ import {
   PanelRightClose,
   PanelRightOpen,
   Palette,
+  Plus,
   Play,
   RotateCcw,
+  Save,
   Search,
   Send,
   Settings,
@@ -45,6 +48,7 @@ import {
   GOMI_HIRABLE_DEPARTMENT_IDS,
   GOMI_MEMORY_EMBEDDING_PROVIDERS,
   assignSeatProvider,
+  deletePromptTemplate,
   fireEmployee,
   getMemoryEmbeddingProviderLabel,
   getProviderLabel,
@@ -67,6 +71,7 @@ import {
   setAvatarStyle,
   setPatchApprovalRequired,
   setSeatWorkMode,
+  savePromptTemplate,
   setSecretRedactionEnabled,
   setSharedMemoryEnabled,
   simulateStaffingScenario,
@@ -167,6 +172,8 @@ export function GomiOfficeApp() {
   const agentStatusesRef = useRef(new Map(BASE_GOMI_AGENTS.map((agent) => [agent.id, agent.status])));
   const nextToastIdRef = useRef(1);
   const [request, setRequest] = useState(GOMI_SAMPLE_REQUEST);
+  const [selectedPromptTemplateId, setSelectedPromptTemplateId] = useState('');
+  const [promptTemplateTitle, setPromptTemplateTitle] = useState('');
   const [isRunning, setIsRunning] = useState(false);
   const [agents, setAgents] = useState<GomiAgent[]>(() =>
     applyOfficeSettingsToAgents(BASE_GOMI_AGENTS, officeSettings)
@@ -191,6 +198,13 @@ export function GomiOfficeApp() {
   const effectiveRightPanelCollapsed = rightPanelCollapsed || sidePanelsAutoCollapsed;
   const effectiveBottomCollapsed = bottomCollapsed || bottomAutoCollapsed;
   const isFullOffice = officeViewMode === 'full-office';
+  const selectedPromptTemplate = useMemo(
+    () =>
+      officeSettings.promptTemplates.find(
+        (promptTemplate) => promptTemplate.id === selectedPromptTemplateId
+      ),
+    [officeSettings.promptTemplates, selectedPromptTemplateId]
+  );
   const visualAgents = useMemo(
     () => applyOfficeSettingsToAgents(agents, officeSettings),
     [agents, officeSettings]
@@ -363,6 +377,62 @@ export function GomiOfficeApp() {
     }
 
     localAbortControllerRef.current?.abort('Gomi Office session stopped from the office controls.');
+  }
+
+  function selectPromptTemplate(templateId: string) {
+    const template = officeSettings.promptTemplates.find(
+      (promptTemplate) => promptTemplate.id === templateId
+    );
+
+    setSelectedPromptTemplateId(template?.id ?? '');
+    setPromptTemplateTitle(template?.title ?? '');
+  }
+
+  function startNewPromptTemplate() {
+    setSelectedPromptTemplateId('');
+    setPromptTemplateTitle(promptTemplateTitleFromBody(request));
+  }
+
+  function saveCurrentPromptTemplate() {
+    const body = request.trim();
+
+    if (!body) {
+      return;
+    }
+
+    const templateId = selectedPromptTemplate?.id ?? createPromptTemplateId();
+    const title = promptTemplateTitle.trim() || promptTemplateTitleFromBody(body);
+
+    setOfficeSettings((currentSettings) =>
+      savePromptTemplate(currentSettings, {
+        id: templateId,
+        title,
+        body,
+        updatedAt: new Date().toISOString()
+      })
+    );
+    setSelectedPromptTemplateId(templateId);
+    setPromptTemplateTitle(title);
+  }
+
+  function applySelectedPromptTemplate() {
+    if (!selectedPromptTemplate) {
+      return;
+    }
+
+    setRequest(selectedPromptTemplate.body);
+  }
+
+  function removeSelectedPromptTemplate() {
+    if (!selectedPromptTemplate) {
+      return;
+    }
+
+    setOfficeSettings((currentSettings) =>
+      deletePromptTemplate(currentSettings, selectedPromptTemplate.id)
+    );
+    setSelectedPromptTemplateId('');
+    setPromptTemplateTitle('');
   }
 
   function approvePatch() {
@@ -852,17 +922,82 @@ export function GomiOfficeApp() {
               aria-label="Project Request"
               spellCheck={false}
             />
-            <div className="gomi-request-actions">
-              <button className="gomi-send" onClick={runOfficeSession} disabled={isRunning}>
-                <Send size={17} />
-                <span>{isRunning ? 'Running' : 'Run CEO'}</span>
-              </button>
-              {isRunning ? (
-                <button className="gomi-send is-stop" onClick={stopOfficeSession}>
-                  <XCircle size={17} />
-                  <span>Stop</span>
+            <div className="gomi-request-sidebar">
+              <div className="gomi-template-tools" aria-label="Prompt Templates">
+                <label className="gomi-template-field">
+                  <span>Template</span>
+                  <select
+                    value={selectedPromptTemplateId}
+                    onChange={(event) => selectPromptTemplate(event.target.value)}
+                    aria-label="Saved prompt template"
+                  >
+                    <option value="">New template</option>
+                    {officeSettings.promptTemplates.map((promptTemplate) => (
+                      <option value={promptTemplate.id} key={promptTemplate.id}>
+                        {promptTemplate.title}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+                <label className="gomi-template-field">
+                  <span>Name</span>
+                  <input
+                    value={promptTemplateTitle}
+                    onChange={(event) => setPromptTemplateTitle(event.target.value)}
+                    aria-label="Prompt template name"
+                    placeholder={promptTemplateTitleFromBody(request)}
+                  />
+                </label>
+                <div className="gomi-template-actions">
+                  <button
+                    className="gomi-icon-button"
+                    onClick={startNewPromptTemplate}
+                    title="New prompt template"
+                    aria-label="New prompt template"
+                  >
+                    <Plus size={16} />
+                  </button>
+                  <button
+                    className="gomi-icon-button"
+                    onClick={saveCurrentPromptTemplate}
+                    disabled={!request.trim()}
+                    title="Save prompt template"
+                    aria-label="Save prompt template"
+                  >
+                    <Save size={16} />
+                  </button>
+                  <button
+                    className="gomi-icon-button"
+                    onClick={applySelectedPromptTemplate}
+                    disabled={!selectedPromptTemplate}
+                    title="Apply prompt template"
+                    aria-label="Apply prompt template"
+                  >
+                    <ClipboardPaste size={16} />
+                  </button>
+                  <button
+                    className="gomi-icon-button is-danger"
+                    onClick={removeSelectedPromptTemplate}
+                    disabled={!selectedPromptTemplate}
+                    title="Delete prompt template"
+                    aria-label="Delete prompt template"
+                  >
+                    <Trash2 size={16} />
+                  </button>
+                </div>
+              </div>
+              <div className="gomi-request-actions">
+                <button className="gomi-send" onClick={runOfficeSession} disabled={isRunning}>
+                  <Send size={17} />
+                  <span>{isRunning ? 'Running' : 'Run CEO'}</span>
                 </button>
-              ) : undefined}
+                {isRunning ? (
+                  <button className="gomi-send is-stop" onClick={stopOfficeSession}>
+                    <XCircle size={17} />
+                    <span>Stop</span>
+                  </button>
+                ) : undefined}
+              </div>
             </div>
           </section>
 
@@ -2098,6 +2233,16 @@ function formatCurrencyEstimate(value: number): string {
     minimumFractionDigits: 4,
     maximumFractionDigits: 4
   }).format(value);
+}
+
+function promptTemplateTitleFromBody(body: string): string {
+  const title = body.split(/\r?\n/, 1)[0]?.replace(/\s+/g, ' ').trim();
+
+  return title ? shortenText(title, 48) : 'Untitled template';
+}
+
+function createPromptTemplateId(): string {
+  return `prompt-template-${Date.now().toString(36)}`;
 }
 
 function isCompactAgentPanelViewport(): boolean {

--- a/src/vs/workbench/contrib/gomi/common/gomiOfficeSettings.ts
+++ b/src/vs/workbench/contrib/gomi/common/gomiOfficeSettings.ts
@@ -9,6 +9,7 @@ import type {
   GomiMemoryEmbeddingProviderId,
   GomiMemoryPrivacyMode,
   GomiOfficeSettings,
+  GomiPromptTemplate,
   GomiRecentProject,
   GomiWorkspaceTrustState
 } from './gomiTypes';
@@ -19,6 +20,7 @@ export const GOMI_DEFAULT_MAX_PROJECT_MEMORY_ITEMS = 420;
 export const GOMI_DEFAULT_MAX_CONCURRENT_AGENT_RUNS = 2;
 export const GOMI_DEFAULT_HTTP_MAX_RETRIES = 2;
 export const GOMI_MAX_RECENT_PROJECTS = 8;
+export const GOMI_MAX_PROMPT_TEMPLATES = 24;
 
 export const GOMI_AVATAR_STYLE_OPTIONS: Array<{
   id: GomiAvatarStyle;
@@ -208,6 +210,7 @@ export const DEFAULT_GOMI_OFFICE_SETTINGS: GomiOfficeSettings = {
     createEmployeeSeat('employee-designer-01', 'designer', 'Product Designer', 'Visual and interaction support'),
     createEmployeeSeat('employee-qa-01', 'qa', 'QA Engineer', 'Test execution support')
   ],
+  promptTemplates: [],
   memory: {
     retrievalMode: 'hybrid-vector',
     embeddingProvider: 'local-hashing',
@@ -231,6 +234,13 @@ export const DEFAULT_GOMI_OFFICE_SETTINGS: GomiOfficeSettings = {
     httpMaxRetries: GOMI_DEFAULT_HTTP_MAX_RETRIES
   }
 };
+
+export interface GomiPromptTemplateDraft {
+  id: string;
+  title?: string;
+  body: string;
+  updatedAt?: string;
+}
 
 export function assignSeatProvider(
   settings: GomiOfficeSettings,
@@ -514,6 +524,35 @@ export function setHttpProviderMaxRetries(
   });
 }
 
+export function savePromptTemplate(
+  settings: GomiOfficeSettings,
+  templateDraft: GomiPromptTemplateDraft
+): GomiOfficeSettings {
+  const template = normalizePromptTemplate(templateDraft);
+
+  if (!template) {
+    return settings;
+  }
+
+  return {
+    ...settings,
+    promptTemplates: [
+      template,
+      ...settings.promptTemplates.filter((currentTemplate) => currentTemplate.id !== template.id)
+    ].slice(0, GOMI_MAX_PROMPT_TEMPLATES)
+  };
+}
+
+export function deletePromptTemplate(
+  settings: GomiOfficeSettings,
+  templateId: string
+): GomiOfficeSettings {
+  return {
+    ...settings,
+    promptTemplates: settings.promptTemplates.filter((template) => template.id !== templateId)
+  };
+}
+
 export function getSeatForAgent(
   settings: GomiOfficeSettings,
   agentId: GomiAgentId
@@ -547,7 +586,8 @@ export function normalizeGomiOfficeSettings(value: unknown): GomiOfficeSettings 
     ...DEFAULT_GOMI_OFFICE_SETTINGS,
     avatarStyle: avatarStyleSetting(rawSettings.avatarStyle),
     recentProjects: normalizeRecentProjects(rawSettings.recentProjects),
-    seats: normalizeSeatSettings(rawSettings.seats)
+    seats: normalizeSeatSettings(rawSettings.seats),
+    promptTemplates: normalizePromptTemplates(rawSettings.promptTemplates)
   };
   const rawMemory: Record<string, unknown> = isRecord(rawSettings.memory) ? rawSettings.memory : {};
   const rawExecution: Record<string, unknown> = isRecord(rawSettings.execution) ? rawSettings.execution : {};
@@ -670,6 +710,52 @@ function updateExecutionSettings(
       ...settings.execution,
       ...executionPatch
     }
+  };
+}
+
+function normalizePromptTemplates(value: unknown): GomiPromptTemplate[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  const seenTemplateIds = new Set<string>();
+  const promptTemplates: GomiPromptTemplate[] = [];
+
+  for (const rawTemplate of value) {
+    const template = normalizePromptTemplate(rawTemplate);
+
+    if (!template || seenTemplateIds.has(template.id)) {
+      continue;
+    }
+
+    seenTemplateIds.add(template.id);
+    promptTemplates.push(template);
+
+    if (promptTemplates.length >= GOMI_MAX_PROMPT_TEMPLATES) {
+      break;
+    }
+  }
+
+  return promptTemplates;
+}
+
+function normalizePromptTemplate(value: unknown): GomiPromptTemplate | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const id = stringSetting(value.id).trim();
+  const body = stringSetting(value.body).trim();
+
+  if (!id || !body) {
+    return undefined;
+  }
+
+  return {
+    id: id.slice(0, 96),
+    title: promptTemplateTitleSetting(value.title, body),
+    body: body.slice(0, 12000),
+    updatedAt: isoDateSetting(value.updatedAt)
   };
 }
 
@@ -973,6 +1059,26 @@ function trimBoundedString(value: unknown, maxLength: number): string | undefine
   const trimmed = value.trim();
 
   return trimmed.length > 0 ? trimmed.slice(0, maxLength) : undefined;
+}
+
+function stringSetting(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function promptTemplateTitleSetting(value: unknown, body: string): string {
+  const explicitTitle = stringSetting(value).trim();
+  const fallbackTitle = body.split(/\r?\n/, 1)[0]?.trim() || 'Untitled template';
+
+  return (explicitTitle || fallbackTitle).slice(0, 80);
+}
+
+function isoDateSetting(value: unknown): string {
+  const candidate = stringSetting(value).trim();
+  const timestamp = candidate ? Date.parse(candidate) : NaN;
+
+  return Number.isFinite(timestamp)
+    ? new Date(timestamp).toISOString()
+    : new Date(0).toISOString();
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/vs/workbench/contrib/gomi/common/gomiTypes.ts
+++ b/src/vs/workbench/contrib/gomi/common/gomiTypes.ts
@@ -111,10 +111,18 @@ export interface GomiRecentProject {
   lastOpenedAt: string;
 }
 
+export interface GomiPromptTemplate {
+  id: string;
+  title: string;
+  body: string;
+  updatedAt: string;
+}
+
 export interface GomiOfficeSettings {
   avatarStyle: GomiAvatarStyle;
   recentProjects: GomiRecentProject[];
   seats: GomiAgentSeat[];
+  promptTemplates: GomiPromptTemplate[];
   memory: GomiOfficeMemorySettings;
   execution: GomiOfficeExecutionSettings;
 }

--- a/tests/gomiOfficeSettingsPersistence.test.ts
+++ b/tests/gomiOfficeSettingsPersistence.test.ts
@@ -4,6 +4,7 @@ import {
   GOMI_MAX_RECENT_PROJECTS,
   rememberRecentProject,
   removeRecentProject,
+  savePromptTemplate,
   setAvatarStyle,
   setMemoryEmbeddingExecutionEnabled,
   setMemoryEmbeddingProvider,
@@ -65,6 +66,29 @@ describe('Gomi office settings persistence', () => {
         name: 'Gomi IDE',
         path: '/workspaces/gomi',
         lastOpenedAt: '2026-07-15T09:30:00.000Z'
+      }
+    ]);
+  });
+
+  it('persists saved prompt templates across reloads', () => {
+    const localStorage = new MemoryLocalStorage();
+    const settings = savePromptTemplate(DEFAULT_GOMI_OFFICE_SETTINGS, {
+      id: 'template-release-review',
+      title: 'Release review',
+      body: 'Draft a release-risk review for this workspace.',
+      updatedAt: '2026-07-13T00:10:00.000Z'
+    });
+
+    persistOfficeSettings(settings, { localStorage });
+
+    const restoredSettings = loadPersistedOfficeSettings({ localStorage });
+
+    expect(restoredSettings.promptTemplates).toEqual([
+      {
+        id: 'template-release-review',
+        title: 'Release review',
+        body: 'Draft a release-risk review for this workspace.',
+        updatedAt: '2026-07-13T00:10:00.000Z'
       }
     ]);
   });

--- a/tests/officeSettings.test.ts
+++ b/tests/officeSettings.test.ts
@@ -5,12 +5,14 @@ import {
   GOMI_HIRABLE_DEPARTMENT_IDS,
   GOMI_MEMORY_EMBEDDING_PROVIDERS,
   assignSeatProvider,
+  deletePromptTemplate,
   fireEmployee,
   getMemoryEmbeddingProviderLabel,
   getSeatForAgent,
   hireEmployee,
   isAgentAvailableForTask,
   normalizeGomiOfficeSettings,
+  savePromptTemplate,
   setMaxProjectMemoryItems,
   setMemoryBroadcastThreshold,
   setMemoryPrivacyMode,
@@ -184,6 +186,39 @@ describe('Gomi office settings', () => {
     expect(geometricSettings.avatarStyle).toBe('geometric');
     expect(initialsSettings.avatarStyle).toBe('initials');
     expect(unsafeSettings.avatarStyle).toBe(DEFAULT_GOMI_OFFICE_SETTINGS.avatarStyle);
+  });
+
+  it('saves, updates, deletes, and normalizes prompt templates', () => {
+    const withTemplate = savePromptTemplate(DEFAULT_GOMI_OFFICE_SETTINGS, {
+      id: 'template-ceo-review',
+      title: ' CEO review ',
+      body: 'Summarize the repo risks.',
+      updatedAt: '2026-07-13T00:00:00.000Z'
+    });
+    const updatedTemplate = savePromptTemplate(withTemplate, {
+      id: 'template-ceo-review',
+      title: 'Risk review',
+      body: 'Summarize release risks and owner actions.',
+      updatedAt: '2026-07-13T00:05:00.000Z'
+    });
+    const normalized = normalizeGomiOfficeSettings({
+      ...updatedTemplate,
+      promptTemplates: [
+        ...updatedTemplate.promptTemplates,
+        { id: '', title: 'Missing id', body: 'ignored' },
+        { id: 'blank-body', title: 'Blank body', body: '   ' }
+      ]
+    });
+
+    expect(normalized.promptTemplates).toEqual([
+      {
+        id: 'template-ceo-review',
+        title: 'Risk review',
+        body: 'Summarize release risks and owner actions.',
+        updatedAt: '2026-07-13T00:05:00.000Z'
+      }
+    ]);
+    expect(deletePromptTemplate(normalized, 'template-ceo-review').promptTemplates).toEqual([]);
   });
 
   it('normalizes persisted settings across versions and rejects unsafe seat state', () => {


### PR DESCRIPTION
## Summary
- Add a saved prompt-template library for the Gomi Office request flow.
- Let users save, apply, and delete reusable templates for the main request textarea.
- Persist templates through the existing Office settings/localStorage path.

## Linked issue / bounty
- Fixes #34
- Refs mergeos-bounties/mergeos#244

## Problem
The Office request box has no reusable prompt-template workflow, so users need to retype or paste common system/user prompts each time.

## Fix
This PR adds local prompt-template settings, UI controls for saving/applying/deleting templates, and targeted persistence coverage for the settings helpers.

## Verification
- `git diff --check upstream/master...HEAD` passed.
- `npm ci` completed; existing npm audit warning reported 11 high-severity vulnerabilities.
- `npm test -- tests/officeSettings.test.ts tests/gomiOfficeSettingsPersistence.test.ts` passed: 2 files, 20 tests.
- `npm run typecheck` passed.
- `npm run build` passed; Vite reported the existing large chunk warning only.

## Risk and rollback
- Templates are local-only; this does not add sync, export, or import support.
- Saved prompt templates persist in localStorage/webview state, so users should avoid saving secrets in reusable templates.
- Reverting this PR removes the template UI and helper state without migration work.

## Maintainer notes
- `package.json` did not expose `lint` or `format:check` scripts in the QA handoff, so those commands were not run.
- No screenshot is attached in this opening handoff; validation is command/test based.
