### PR TITLE
Add Office avatar style selection

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -777,6 +777,29 @@ button {
   line-height: 1.45;
 }
 
+.gomi-avatar-style-controls {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.gomi-avatar-style-controls button {
+  min-height: 34px;
+  border: 1px solid #334155;
+  border-radius: 7px;
+  background: #101826;
+  color: #cbd5e1;
+  font-size: 12px;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.gomi-avatar-style-controls button.is-active {
+  border-color: #2dd4bf;
+  background: #0f766e;
+  color: #ecfeff;
+}
+
 .gomi-memory-summary {
   display: flex;
   flex-wrap: wrap;

--- a/src/vs/workbench/contrib/gomi/browser/GomiOfficeApp.tsx
+++ b/src/vs/workbench/contrib/gomi/browser/GomiOfficeApp.tsx
@@ -35,6 +35,7 @@ import {
 } from 'lucide-react';
 import { BASE_GOMI_AGENTS, GOMI_SAMPLE_REQUEST } from '../common/gomiConstants';
 import {
+  GOMI_AVATAR_STYLE_OPTIONS,
   GOMI_AGENT_CLI_PROVIDERS,
   GOMI_HIRABLE_DEPARTMENT_IDS,
   GOMI_MEMORY_EMBEDDING_PROVIDERS,
@@ -55,6 +56,7 @@ import {
   setMemoryEmbeddingProvider,
   setMemoryPrivacyMode,
   setMemoryRetentionDays,
+  setAvatarStyle,
   setPatchApprovalRequired,
   setSeatWorkMode,
   setSecretRedactionEnabled,
@@ -66,6 +68,7 @@ import {
 import type {
   GomiAgent,
   GomiAgentCliProviderId,
+  GomiAvatarStyle,
   GomiAgentId,
   GomiAgentSeat,
   GomiChatMessage,
@@ -548,6 +551,10 @@ export function GomiOfficeApp() {
     );
   }
 
+  function updateAvatarStyle(avatarStyle: GomiAvatarStyle) {
+    setOfficeSettings((currentSettings) => setAvatarStyle(currentSettings, avatarStyle));
+  }
+
   function updatePatchApprovalRequired(requirePatchApproval: boolean) {
     setOfficeSettings((currentSettings) =>
       setPatchApprovalRequired(currentSettings, requirePatchApproval)
@@ -775,6 +782,7 @@ export function GomiOfficeApp() {
           onSecretRedactionChange={updateSecretRedaction}
           onMemoryRetentionDaysChange={updateMemoryRetentionDays}
           onMaxProjectMemoryItemsChange={updateMaxProjectMemoryItems}
+          onAvatarStyleChange={updateAvatarStyle}
           onPatchApprovalRequiredChange={updatePatchApprovalRequired}
           onWorkspaceTrustChange={updateWorkspaceTrust}
           onLiveProviderModeChange={updateLiveProviderMode}
@@ -890,6 +898,7 @@ function RightPanel({
   onSecretRedactionChange,
   onMemoryRetentionDaysChange,
   onMaxProjectMemoryItemsChange,
+  onAvatarStyleChange,
   onPatchApprovalRequiredChange,
   onWorkspaceTrustChange,
   onLiveProviderModeChange,
@@ -923,6 +932,7 @@ function RightPanel({
   onSecretRedactionChange: (redactSecrets: boolean) => void;
   onMemoryRetentionDaysChange: (retentionDays: number) => void;
   onMaxProjectMemoryItemsChange: (maxProjectMemoryItems: number) => void;
+  onAvatarStyleChange: (avatarStyle: GomiAvatarStyle) => void;
   onPatchApprovalRequiredChange: (requirePatchApproval: boolean) => void;
   onWorkspaceTrustChange: (workspaceTrust: GomiWorkspaceTrustState) => void;
   onLiveProviderModeChange: (liveProviderMode: GomiLiveProviderMode) => void;
@@ -990,6 +1000,7 @@ function RightPanel({
           onSecretRedactionChange={onSecretRedactionChange}
           onMemoryRetentionDaysChange={onMemoryRetentionDaysChange}
           onMaxProjectMemoryItemsChange={onMaxProjectMemoryItemsChange}
+          onAvatarStyleChange={onAvatarStyleChange}
           onPatchApprovalRequiredChange={onPatchApprovalRequiredChange}
           onWorkspaceTrustChange={onWorkspaceTrustChange}
           onLiveProviderModeChange={onLiveProviderModeChange}
@@ -1059,6 +1070,7 @@ function OfficeSettingsPanel({
   onSecretRedactionChange,
   onMemoryRetentionDaysChange,
   onMaxProjectMemoryItemsChange,
+  onAvatarStyleChange,
   onPatchApprovalRequiredChange,
   onWorkspaceTrustChange,
   onLiveProviderModeChange,
@@ -1088,6 +1100,7 @@ function OfficeSettingsPanel({
   onSecretRedactionChange: (redactSecrets: boolean) => void;
   onMemoryRetentionDaysChange: (retentionDays: number) => void;
   onMaxProjectMemoryItemsChange: (maxProjectMemoryItems: number) => void;
+  onAvatarStyleChange: (avatarStyle: GomiAvatarStyle) => void;
   onPatchApprovalRequiredChange: (requirePatchApproval: boolean) => void;
   onWorkspaceTrustChange: (workspaceTrust: GomiWorkspaceTrustState) => void;
   onLiveProviderModeChange: (liveProviderMode: GomiLiveProviderMode) => void;
@@ -1119,6 +1132,24 @@ function OfficeSettingsPanel({
       <div className="gomi-panel-header">
         <span>Office Settings</span>
         <Settings size={16} />
+      </div>
+
+      <div className="gomi-settings-group">
+        <div className="gomi-settings-title">Office Appearance</div>
+        <div className="gomi-avatar-style-controls" role="radiogroup" aria-label="Agent avatar style">
+          {GOMI_AVATAR_STYLE_OPTIONS.map((option) => (
+            <button
+              className={officeSettings.avatarStyle === option.id ? 'is-active' : ''}
+              key={option.id}
+              type="button"
+              role="radio"
+              aria-checked={officeSettings.avatarStyle === option.id}
+              onClick={() => onAvatarStyleChange(option.id)}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
       </div>
 
       <div className="gomi-settings-group">

--- a/src/vs/workbench/contrib/gomi/browser/PhaserOffice.tsx
+++ b/src/vs/workbench/contrib/gomi/browser/PhaserOffice.tsx
@@ -3,6 +3,7 @@ import Phaser from 'phaser';
 import type {
   GomiAgent,
   GomiAgentSeat,
+  GomiAvatarStyle,
   GomiChatMessage,
   GomiMemoryBoardItem,
   GomiOfficeSettings,
@@ -53,6 +54,17 @@ const roleColors: Record<GomiAgent['id'], number> = {
   database: 0x38bdf8,
   qa: 0xfbbf24,
   devops: 0x34d399
+};
+
+const roleEmojis: Record<GomiAgent['id'], string> = {
+  ceo: '🧭',
+  'system-analyst': '🧩',
+  backend: '🛠️',
+  frontend: '🎨',
+  designer: '✨',
+  database: '🗄️',
+  qa: '✅',
+  devops: '🚀'
 };
 
 export function PhaserOffice({
@@ -148,7 +160,12 @@ export function PhaserOffice({
         this.drawStatusWall(graphics, officeLayout.statusWall, nextAgents, nextTasks, nextOfficeSettings.seats);
         this.drawGomiRoute(graphics, officeLayout.gomiHub, officeLayout.seats, nextAgents);
         this.drawConversationRoute(graphics, activeConversation);
-        this.drawDepartmentStaff(graphics, officeLayout.rooms, nextOfficeSettings.seats);
+        this.drawDepartmentStaff(
+          graphics,
+          officeLayout.rooms,
+          nextOfficeSettings.seats,
+          nextOfficeSettings.avatarStyle
+        );
 
         for (const agent of nextAgents) {
           const seat = officeLayout.seats.find((candidate) => candidate.agentId === agent.id);
@@ -160,6 +177,7 @@ export function PhaserOffice({
 
           this.drawAgent(
             agent,
+            nextOfficeSettings.avatarStyle,
             width,
             height,
             isConversationAgent ? undefined : agentBubbleText,
@@ -383,7 +401,8 @@ export function PhaserOffice({
       private drawDepartmentStaff(
         graphics: Phaser.GameObjects.Graphics,
         rooms: GomiOfficeRoomLayout[],
-        seats: GomiAgentSeat[]
+        seats: GomiAgentSeat[],
+        avatarStyle: GomiAvatarStyle
       ) {
         const employees = seats.filter((seat) => seat.seatKind === 'employee');
 
@@ -394,7 +413,7 @@ export function PhaserOffice({
           const firedEmployees = departmentEmployees.filter((seat) => seat.workMode === 'fired');
 
           activeEmployees.slice(0, 6).forEach((seat, index) => {
-            this.drawEmployeeAvatar(seat, roomLayout, index, activeEmployees.length);
+            this.drawEmployeeAvatar(seat, roomLayout, index, activeEmployees.length, avatarStyle);
           });
 
           if (activeEmployees.length > 6) {
@@ -411,7 +430,8 @@ export function PhaserOffice({
         seat: GomiAgentSeat,
         roomLayout: GomiOfficeRoomLayout,
         index: number,
-        total: number
+        total: number,
+        avatarStyle: GomiAvatarStyle
       ) {
         const columns = roomLayout.width < 120 ? 2 : 3;
         const spacingX = Math.min(31, Math.max(22, roomLayout.width / (columns + 1)));
@@ -435,12 +455,25 @@ export function PhaserOffice({
         const group = this.add.container(x, y);
 
         group.add(this.add.ellipse(0, 15, 28, 10, 0x475569, 0.16));
-        group.add(this.add.circle(0, -4, 11, 0xffedd5, 1));
+        group.add(this.add.circle(0, -4, 11, avatarStyle === 'geometric' ? 0xffffff : 0xffedd5, 1));
         group.add(this.add.rectangle(0, 13, 18, 18, color, 0.95).setOrigin(0.5));
         group.add(this.add.rectangle(0, -13, 17, 7, color, 0.92).setOrigin(0.5));
-        group.add(this.add.circle(-4, -5, 1.4, 0x111827, 1));
-        group.add(this.add.circle(4, -5, 1.4, 0x111827, 1));
-        group.add(this.add.arc(0, -1, 4, 20, 160, false).setStrokeStyle(1, 0x111827));
+        if (avatarStyle === 'emoji') {
+          group.add(this.add.text(0, -13, roleEmojis[seat.agentId], {
+            fontFamily: 'Apple Color Emoji, Segoe UI Emoji, Noto Color Emoji, sans-serif',
+            fontSize: '14px'
+          }).setOrigin(0.5, 0));
+        } else if (avatarStyle === 'initials') {
+          group.add(this.add.text(0, -10, this.initialsForLabel(seat.name), {
+            color: '#0f172a',
+            fontFamily: 'Inter, Arial',
+            fontSize: '8px',
+            fontStyle: '800'
+          }).setOrigin(0.5, 0));
+        } else {
+          group.add(this.add.circle(-5, -5, 4, color, 0.95));
+          group.add(this.add.triangle(5, -5, 0, -5, 8, 5, -8, 5, color, 0.88));
+        }
         group.add(this.add.circle(10, -14, 3.8, 0x22c55e, 1));
 
         if (total > 1) {
@@ -520,6 +553,7 @@ export function PhaserOffice({
 
       private drawAgent(
         agent: GomiAgent,
+        avatarStyle: GomiAvatarStyle,
         width: number,
         height: number,
         bubbleText?: string,
@@ -544,14 +578,35 @@ export function PhaserOffice({
         group.add(this.add.ellipse(0, 28, 54, 18, 0x475569, 0.18));
         group.add(leftLeg);
         group.add(rightLeg);
-        group.add(this.add.rectangle(0, 11, 34, 36, color, 1).setOrigin(0.5));
-        group.add(this.add.circle(0, -18, 22, 0xffedd5, 1));
-        group.add(this.add.rectangle(0, -33, 36, 14, color, 1).setOrigin(0.5));
-        group.add(this.add.circle(-8, -20, 2.4, 0x111827, 1));
-        group.add(this.add.circle(8, -20, 2.4, 0x111827, 1));
-        group.add(this.add.circle(-13, -13, 3, 0xfca5a5, 0.75));
-        group.add(this.add.circle(13, -13, 3, 0xfca5a5, 0.75));
-        group.add(this.add.arc(0, -13, 8, 20, 160, false).setStrokeStyle(2, 0x111827));
+        group.add(this.add.rectangle(0, 13, 34, 34, color, 1).setOrigin(0.5));
+
+        if (avatarStyle === 'geometric') {
+          group.add(this.add.circle(0, -19, 24, 0xf8fafc, 1).setStrokeStyle(4, color));
+          group.add(this.add.triangle(0, -19, 0, -16, 17, 12, -17, 12, color, 0.95));
+          group.add(this.add.rectangle(0, -23, 22, 9, statusColor, 0.9).setOrigin(0.5));
+        } else if (avatarStyle === 'initials') {
+          group.add(this.add.circle(0, -19, 24, 0xffffff, 1).setStrokeStyle(4, color));
+          group.add(
+            this.add
+              .text(0, -29, this.initialsForLabel(agent.name), {
+                color: '#0f172a',
+                fontFamily: 'Inter, Arial',
+                fontSize: '18px',
+                fontStyle: '800'
+              })
+              .setOrigin(0.5, 0)
+          );
+        } else {
+          group.add(this.add.circle(0, -19, 24, 0xffffff, 1).setStrokeStyle(4, color));
+          group.add(
+            this.add
+              .text(0, -33, roleEmojis[agent.id], {
+                fontFamily: 'Apple Color Emoji, Segoe UI Emoji, Noto Color Emoji, sans-serif',
+                fontSize: '24px'
+              })
+              .setOrigin(0.5, 0)
+          );
+        }
 
         const badge = this.add.circle(24, -34, 7, statusColor, 1);
         group.add(badge);
@@ -936,6 +991,16 @@ export function PhaserOffice({
         }
 
         return `${value.slice(0, Math.max(0, maxLength - 3))}...`;
+      }
+
+      private initialsForLabel(value: string): string {
+        return value
+          .replace(/\bAgent\b/g, '')
+          .split(/\s+/)
+          .filter(Boolean)
+          .slice(0, 2)
+          .map((part) => part[0]?.toUpperCase() ?? '')
+          .join('');
       }
     }
 

--- a/src/vs/workbench/contrib/gomi/common/gomiOfficeSettings.ts
+++ b/src/vs/workbench/contrib/gomi/common/gomiOfficeSettings.ts
@@ -4,6 +4,7 @@ import type {
   GomiAgentId,
   GomiAgentSeat,
   GomiAgentWorkMode,
+  GomiAvatarStyle,
   GomiLiveProviderMode,
   GomiMemoryEmbeddingProviderId,
   GomiMemoryPrivacyMode,
@@ -15,6 +16,15 @@ export const GOMI_DEFAULT_MEMORY_BROADCAST_THRESHOLD = 0.74;
 export const GOMI_DEFAULT_MEMORY_RETENTION_DAYS = 30;
 export const GOMI_DEFAULT_MAX_PROJECT_MEMORY_ITEMS = 420;
 export const GOMI_DEFAULT_MAX_CONCURRENT_AGENT_RUNS = 2;
+
+export const GOMI_AVATAR_STYLE_OPTIONS: Array<{
+  id: GomiAvatarStyle;
+  label: string;
+}> = [
+  { id: 'emoji', label: 'Emoji' },
+  { id: 'geometric', label: 'Geometric' },
+  { id: 'initials', label: 'Initials' }
+];
 
 export const GOMI_HIRABLE_DEPARTMENT_IDS: GomiAgentId[] = [
   'system-analyst',
@@ -169,6 +179,7 @@ export const GOMI_AGENT_CLI_PROVIDERS: GomiAgentCliProvider[] = [
 ];
 
 export const DEFAULT_GOMI_OFFICE_SETTINGS: GomiOfficeSettings = {
+  avatarStyle: 'emoji',
   seats: [
     {
       id: 'seat-ceo',
@@ -381,6 +392,16 @@ export function setMaxProjectMemoryItems(
   });
 }
 
+export function setAvatarStyle(
+  settings: GomiOfficeSettings,
+  avatarStyle: GomiAvatarStyle
+): GomiOfficeSettings {
+  return {
+    ...settings,
+    avatarStyle
+  };
+}
+
 export function setPatchApprovalRequired(
   settings: GomiOfficeSettings,
   requirePatchApproval: boolean
@@ -480,6 +501,7 @@ export function normalizeGomiOfficeSettings(value: unknown): GomiOfficeSettings 
   const rawSettings = value as Partial<GomiOfficeSettings>;
   let normalizedSettings: GomiOfficeSettings = {
     ...DEFAULT_GOMI_OFFICE_SETTINGS,
+    avatarStyle: avatarStyleSetting(rawSettings.avatarStyle),
     seats: normalizeSeatSettings(rawSettings.seats)
   };
   const rawMemory: Record<string, unknown> = isRecord(rawSettings.memory) ? rawSettings.memory : {};
@@ -752,6 +774,12 @@ function memoryPrivacyModeSetting(value: unknown): GomiMemoryPrivacyMode {
   return value === 'strict' || value === 'standard'
     ? value
     : DEFAULT_GOMI_OFFICE_SETTINGS.memory.privacyMode;
+}
+
+function avatarStyleSetting(value: unknown): GomiAvatarStyle {
+  return GOMI_AVATAR_STYLE_OPTIONS.some((option) => option.id === value)
+    ? value as GomiAvatarStyle
+    : DEFAULT_GOMI_OFFICE_SETTINGS.avatarStyle;
 }
 
 function workspaceTrustSetting(value: unknown): GomiWorkspaceTrustState {

--- a/src/vs/workbench/contrib/gomi/common/gomiTypes.ts
+++ b/src/vs/workbench/contrib/gomi/common/gomiTypes.ts
@@ -29,6 +29,7 @@ export type GomiPatchApprovalStatus =
 export type GomiPatchRiskLevel = 'low' | 'medium' | 'high';
 export type GomiMemoryKind = 'request' | 'workspace' | 'agent_result' | 'patch' | 'report';
 export type GomiMemoryPrivacyMode = 'standard' | 'strict';
+export type GomiAvatarStyle = 'emoji' | 'geometric' | 'initials';
 export type GomiAgentCliProviderId =
   | 'codex-cli'
   | 'claude-code'
@@ -103,6 +104,7 @@ export interface GomiOfficeExecutionSettings {
 }
 
 export interface GomiOfficeSettings {
+  avatarStyle: GomiAvatarStyle;
   seats: GomiAgentSeat[];
   memory: GomiOfficeMemorySettings;
   execution: GomiOfficeExecutionSettings;

--- a/tests/gomiOfficeSettingsPersistence.test.ts
+++ b/tests/gomiOfficeSettingsPersistence.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   DEFAULT_GOMI_OFFICE_SETTINGS,
+  setAvatarStyle,
   setMemoryEmbeddingExecutionEnabled,
   setMemoryEmbeddingProvider,
   setSeatWorkMode
@@ -37,13 +38,17 @@ describe('Gomi office settings persistence', () => {
 
   it('falls back to browser local storage for the standalone office demo', () => {
     const localStorage = new MemoryLocalStorage();
-    const settings = setSeatWorkMode(DEFAULT_GOMI_OFFICE_SETTINGS, 'head-frontend', 'sleeping');
+    const settings = setAvatarStyle(
+      setSeatWorkMode(DEFAULT_GOMI_OFFICE_SETTINGS, 'head-frontend', 'sleeping'),
+      'initials'
+    );
 
     persistOfficeSettings(settings, { localStorage });
 
     const restoredSettings = loadPersistedOfficeSettings({ localStorage });
 
     expect(restoredSettings.seats.find((seat) => seat.id === 'head-frontend')?.workMode).toBe('sleeping');
+    expect(restoredSettings.avatarStyle).toBe('initials');
   });
 
   it('normalizes corrupted persisted payloads back to safe defaults', () => {

--- a/tests/officeSettings.test.ts
+++ b/tests/officeSettings.test.ts
@@ -28,7 +28,8 @@ import {
   simulateStaffingScenario,
   setWorkspaceTrustState,
   setSharedMemoryEnabled,
-  setWorkspaceContextIndexing
+  setWorkspaceContextIndexing,
+  setAvatarStyle
 } from '../src/vs/workbench/contrib/gomi/common/gomiOfficeSettings';
 
 describe('Gomi office settings', () => {
@@ -165,6 +166,23 @@ describe('Gomi office settings', () => {
     expect(httpEmbeddings.memory.embeddingExecutionEnabled).toBe(true);
     expect(localHashing.memory.embeddingProvider).toBe('local-hashing');
     expect(localHashing.memory.embeddingExecutionEnabled).toBe(false);
+  });
+
+  it('updates and normalizes persisted avatar style settings', () => {
+    const geometricSettings = setAvatarStyle(DEFAULT_GOMI_OFFICE_SETTINGS, 'geometric');
+    const initialsSettings = normalizeGomiOfficeSettings({
+      ...geometricSettings,
+      avatarStyle: 'initials'
+    });
+    const unsafeSettings = normalizeGomiOfficeSettings({
+      ...geometricSettings,
+      avatarStyle: 'remote-image'
+    });
+
+    expect(DEFAULT_GOMI_OFFICE_SETTINGS.avatarStyle).toBe('emoji');
+    expect(geometricSettings.avatarStyle).toBe('geometric');
+    expect(initialsSettings.avatarStyle).toBe('initials');
+    expect(unsafeSettings.avatarStyle).toBe(DEFAULT_GOMI_OFFICE_SETTINGS.avatarStyle);
   });
 
   it('normalizes persisted settings across versions and rejects unsafe seat state', () => {


### PR DESCRIPTION
## Summary
- Adds an Office Settings control for choosing the agent avatar style: Emoji, Geometric, or Initials.
- Persists the selected style through the Gomi office settings path and webview state.
- Updates the Phaser office scene so the selected avatar style is rendered consistently.

## Linked issue / bounty
- Fixes https://github.com/mergeos-bounties/Gomi/issues/24

## Problem
Gomi Office used a single avatar presentation, so users could not switch between emoji, geometric, and initials-based agent avatar styles from Office Settings.

## Fix
- Adds an `avatarStyle` office setting with supported style validation and persistence.
- Adds the Office Settings UI option for avatar style selection.
- Renders distinct emoji, geometric, and initials avatars in the Phaser office scene.
- Extends office settings and persistence tests for the new setting.

## Verification
QA approved commit `4b52ffaee9cbafbe48c6d8cc1d4f4605ddd285f9` with:
- `git diff --check HEAD~1..HEAD`
- `npm ci`
- `npm test -- tests/officeSettings.test.ts tests/gomiOfficeSettingsPersistence.test.ts tests/gomiOfficeLayout.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run verify:release`
- `npm run build`
- `npm run build:webview`
- Static Playwright build check covering Emoji/Geometric/Initials settings visibility, canvas rendering, distinct canvas hashes, Initials persistence across reload, and no external requests.

Results recorded by QA:
- Targeted tests passed: 23 tests.
- Full tests passed: 138 passed / 3 skipped.
- Release verification passed: 6 passed / 1 skipped.
- Web and webview builds passed with the existing Vite large-chunk warning.

## Risk and rollback
Risk is limited to Gomi Office settings persistence and avatar rendering. Reverting this PR removes the avatar-style setting and restores the previous single avatar presentation.

## Maintainer attention
- `npm run lint` and `npm run format:check` are not available in `package.json`, so they were not run.
- `npm ci` reported existing dependency audit output for 11 high severity vulnerabilities.
- Emoji rendering can vary slightly by platform font; geometric and initials modes are shape/text based and were checked separately.

## Visual evidence
QA visual evidence for the three Office avatar style paths is public here: https://gist.github.com/Rajesh270712/394d136f203cd772203aca6aa8610044

- Emoji avatar style:

![Gomi Office emoji avatar style](https://gist.githubusercontent.com/Rajesh270712/394d136f203cd772203aca6aa8610044/raw/a4adf34894222f1b5e691d3b0ad9e9437f4073f4/gomi-office-avatar-emoji.png)

- Geometric avatar style:

![Gomi Office geometric avatar style](https://gist.githubusercontent.com/Rajesh270712/394d136f203cd772203aca6aa8610044/raw/aa537fbc6c244f1ca6b0a505f8cb07ef29ddcd94/gomi-office-avatar-geometric.png)

- Initials avatar style:

![Gomi Office initials avatar style](https://gist.githubusercontent.com/Rajesh270712/394d136f203cd772203aca6aa8610044/raw/1f2102d86b53f9fa9d42147b02635a339c1b0b10/gomi-office-avatar-initials.png)

Canvas hash summary: https://gist.githubusercontent.com/Rajesh270712/394d136f203cd772203aca6aa8610044/raw/1e8feff37c6f548656a464ce4812ed1b51e1471b/gomi-office-avatar-hash-summary.txt