### PR TITLE
Add Code OSS dry-run integration report

### DIFF
--- a/docs/windows-release.md
+++ b/docs/windows-release.md
@@ -120,6 +120,17 @@ powershell -ExecutionPolicy Bypass -File .\scripts\build-gomi-code-oss-windows.p
   -DryRun
 ```
 
+For the lower-level manifest apply step, write a dry-run report outside the Code - OSS checkout so the target tree remains unchanged:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\apply-gomi-code-oss-integration.ps1 `
+  -CodeOssRoot D:\path\to\code-oss-fork `
+  -DryRun `
+  -ReportPath .\artifacts\gomi-code-oss-dry-run-report.json
+```
+
+The dry-run report lists the planned manifest actions and matching rollback steps, such as restoring `product.json`, removing copied Gomi module paths, or removing the appended workbench import. In dry-run mode the report path is rejected if it is inside the Code - OSS checkout.
+
 ## Why EXE, Not NPM
 
 End users should not run Gomi IDE with `npm run dev`.

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "preview": "vite preview --host 127.0.0.1",
     "test": "vitest run",
     "typecheck": "tsc -b",
-    "verify:release": "vitest run tests/releaseReadiness.test.ts tests/codeOssIntegrationManifest.test.ts",
+    "verify:release": "vitest run tests/releaseReadiness.test.ts tests/codeOssIntegrationManifest.test.ts tests/codeOssIntegrationDryRun.test.ts",
     "electron:start": "electron .",
     "electron:dev": "node scripts/run-electron-dev.mjs",
     "desktop:dir": "npm run build && electron-builder --win --dir",

--- a/scripts/apply-gomi-code-oss-integration.ps1
+++ b/scripts/apply-gomi-code-oss-integration.ps1
@@ -4,10 +4,152 @@ param(
 
   [string]$ManifestPath,
   [switch]$ValidateOnly,
-  [switch]$DryRun
+  [switch]$DryRun,
+  [string]$ReportPath
 )
 
 $ErrorActionPreference = 'Stop'
+
+$script:GomiIntegrationReportActions = @()
+$script:GomiIntegrationRollbackActions = @()
+
+function Test-GomiPathIsUnderRoot {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$PathValue,
+
+    [Parameter(Mandatory = $true)]
+    [string]$RootPath
+  )
+
+  $comparison = if ([System.Environment]::OSVersion.Platform -eq [System.PlatformID]::Win32NT) {
+    [System.StringComparison]::OrdinalIgnoreCase
+  } else {
+    [System.StringComparison]::Ordinal
+  }
+  $fullPath = [System.IO.Path]::GetFullPath($PathValue)
+  $fullRoot = [System.IO.Path]::GetFullPath($RootPath)
+  $rootPrefix = if ($fullRoot.EndsWith([System.IO.Path]::DirectorySeparatorChar)) {
+    $fullRoot
+  } else {
+    "$fullRoot$([System.IO.Path]::DirectorySeparatorChar)"
+  }
+
+  return $fullPath.Equals($fullRoot, $comparison) -or $fullPath.StartsWith($rootPrefix, $comparison)
+}
+
+function Resolve-GomiReportPath {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$PathValue,
+
+    [Parameter(Mandatory = $true)]
+    [string]$CodeRoot
+  )
+
+  $resolvedPath = if ([System.IO.Path]::IsPathRooted($PathValue)) {
+    [System.IO.Path]::GetFullPath($PathValue)
+  } else {
+    [System.IO.Path]::GetFullPath((Join-Path (Get-Location).Path $PathValue))
+  }
+
+  if ($DryRun -and (Test-GomiPathIsUnderRoot -PathValue $resolvedPath -RootPath $CodeRoot)) {
+    throw "Dry-run report path must be outside the Code - OSS checkout so dry-run leaves the target tree unchanged: $resolvedPath"
+  }
+
+  return $resolvedPath
+}
+
+function Add-GomiIntegrationReportAction {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Kind,
+
+    [string]$Source,
+    [string]$Destination,
+    [string]$Message,
+    [hashtable]$Data = @{}
+  )
+
+  $entry = [ordered]@{
+    kind = $Kind
+    source = $Source
+    destination = $Destination
+    message = $Message
+  }
+
+  foreach ($key in $Data.Keys) {
+    $entry[$key] = $Data[$key]
+  }
+
+  $script:GomiIntegrationReportActions += [pscustomobject]$entry
+}
+
+function Add-GomiIntegrationRollbackAction {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Kind,
+
+    [string]$Target,
+    [string]$Message,
+    [hashtable]$Data = @{}
+  )
+
+  $entry = [ordered]@{
+    kind = $Kind
+    target = $Target
+    message = $Message
+  }
+
+  foreach ($key in $Data.Keys) {
+    $entry[$key] = $Data[$key]
+  }
+
+  $script:GomiIntegrationRollbackActions += [pscustomobject]$entry
+}
+
+function Write-GomiIntegrationReport {
+  param(
+    [string]$PathValue,
+
+    [Parameter(Mandatory = $true)]
+    [string]$RepoRoot,
+
+    [Parameter(Mandatory = $true)]
+    [string]$CodeRoot,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ManifestFile
+  )
+
+  $report = [ordered]@{
+    schemaVersion = 1
+    generatedAt = (Get-Date).ToUniversalTime().ToString('o')
+    repoRoot = $RepoRoot
+    codeOssRoot = $CodeRoot
+    manifestPath = $ManifestFile
+    validateOnly = [bool]$ValidateOnly
+    dryRun = [bool]$DryRun
+    actions = @($script:GomiIntegrationReportActions)
+    rollbackActions = @($script:GomiIntegrationRollbackActions)
+  }
+
+  if (-not $PathValue) {
+    Write-Host "Integration report summary: $($script:GomiIntegrationReportActions.Count) actions, $($script:GomiIntegrationRollbackActions.Count) rollback steps." -ForegroundColor Green
+    return
+  }
+
+  $reportParent = Split-Path -Parent $PathValue
+
+  if ($reportParent) {
+    New-Item -ItemType Directory -Force -Path $reportParent | Out-Null
+  }
+
+  $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+  $reportJson = $report | ConvertTo-Json -Depth 32
+  [System.IO.File]::WriteAllText($PathValue, "$reportJson`n", $utf8NoBom)
+  Write-Host "Integration report written: $PathValue" -ForegroundColor Green
+}
 
 function Resolve-GomiPath {
   param(
@@ -35,6 +177,14 @@ function Copy-GomiIntegrationItem {
   )
 
   Write-Host "Copy $Source -> $Destination" -ForegroundColor DarkCyan
+  $destinationExists = Test-Path -LiteralPath $Destination
+  Add-GomiIntegrationReportAction -Kind 'copy' -Source $Source -Destination $Destination -Message 'Copy integration file or directory into the Code - OSS checkout.'
+
+  if ($destinationExists) {
+    Add-GomiIntegrationRollbackAction -Kind 'restore-path' -Target $Destination -Message 'Restore the previous destination contents from source control or a pre-apply backup.'
+  } else {
+    Add-GomiIntegrationRollbackAction -Kind 'remove-path' -Target $Destination -Message 'Remove the copied destination path.'
+  }
 
   if ($ValidateOnly -or $DryRun) {
     return
@@ -99,6 +249,11 @@ function Set-GomiProductJson {
     return
   }
 
+  Add-GomiIntegrationReportAction -Kind 'merge-product-json' -Source $Source -Destination $Destination -Message 'Merge Gomi product metadata into Code - OSS product.json.' -Data @{
+    removeKeys = @($RemoveKeys)
+  }
+  Add-GomiIntegrationRollbackAction -Kind 'restore-file' -Target $Destination -Message 'Restore product.json from source control or the pre-apply backup created by the caller.'
+
   if ($ValidateOnly -or $DryRun) {
     return
   }
@@ -137,10 +292,20 @@ function Add-GomiWorkbenchImport {
 
   if ($content.Contains($ImportLine)) {
     Write-Host "Import already present in $TargetFile" -ForegroundColor DarkCyan
+    Add-GomiIntegrationReportAction -Kind 'ensure-workbench-import' -Destination $TargetFile -Message 'Workbench import already exists.' -Data @{
+      import = $ImportLine
+      changed = $false
+    }
     return
   }
 
   Write-Host "Patch $TargetFile with: $ImportLine" -ForegroundColor DarkCyan
+  Add-GomiIntegrationReportAction -Kind 'append-workbench-import' -Destination $TargetFile -Message 'Append the native Gomi workbench contribution import.' -Data @{
+    import = $ImportLine
+  }
+  Add-GomiIntegrationRollbackAction -Kind 'remove-workbench-import' -Target $TargetFile -Message 'Remove the appended Gomi workbench contribution import line.' -Data @{
+    import = $ImportLine
+  }
 
   if ($ValidateOnly -or $DryRun) {
     return
@@ -163,6 +328,11 @@ $manifestFile = if ($ManifestPath) {
 } else {
   Resolve-GomiPath -PathValue (Join-Path $repoRoot 'build/gomi-code-oss.integration.json') -Description 'Gomi integration manifest'
 }
+$resolvedReportPath = if ($ReportPath) {
+  Resolve-GomiReportPath -PathValue $ReportPath -CodeRoot $codeRoot
+} else {
+  $null
+}
 
 $manifest = Get-Content -LiteralPath $manifestFile -Raw | ConvertFrom-Json
 
@@ -174,6 +344,9 @@ Write-Host "Applying Gomi Code - OSS integration manifest: $manifestFile" -Foreg
 Write-Host "Code - OSS root: $codeRoot" -ForegroundColor Green
 Write-Host "Validate only: $($ValidateOnly.IsPresent)" -ForegroundColor Green
 Write-Host "Dry run: $($DryRun.IsPresent)" -ForegroundColor Green
+if ($resolvedReportPath) {
+  Write-Host "Report path: $resolvedReportPath" -ForegroundColor Green
+}
 
 $productSource = Resolve-GomiPath -PathValue (Join-Path $repoRoot $manifest.productJson.source) -Description 'Gomi product.json'
 $productTarget = Join-Path $codeRoot $manifest.productJson.target
@@ -207,6 +380,10 @@ foreach ($copy in $manifest.webviewAssetCopies) {
     if ($ValidateOnly -or $DryRun) {
       Write-Host $message -ForegroundColor Yellow
       Write-Host "Copy $sourcePath -> $target" -ForegroundColor DarkCyan
+      Add-GomiIntegrationReportAction -Kind 'copy' -Source $sourcePath -Destination $target -Message $message -Data @{
+        sourceMissing = $true
+      }
+      Add-GomiIntegrationRollbackAction -Kind 'remove-path' -Target $target -Message 'Remove generated webview assets if a later non-dry-run apply creates them.'
       continue
     }
 
@@ -227,5 +404,7 @@ foreach ($workbenchImport in $manifest.workbenchImports) {
   $target = Join-Path $codeRoot $workbenchImport.target
   Add-GomiWorkbenchImport -TargetFile $target -ImportLine $workbenchImport.import
 }
+
+Write-GomiIntegrationReport -PathValue $resolvedReportPath -RepoRoot $repoRoot -CodeRoot $codeRoot -ManifestFile $manifestFile
 
 Write-Host 'Gomi Code - OSS integration manifest completed.' -ForegroundColor Green

--- a/scripts/fixtures/code-oss-dry-run/package.json
+++ b/scripts/fixtures/code-oss-dry-run/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "code-oss-dry-run-fixture",
+  "version": "0.0.0"
+}

--- a/scripts/fixtures/code-oss-dry-run/product.json
+++ b/scripts/fixtures/code-oss-dry-run/product.json
@@ -1,0 +1,11 @@
+{
+  "nameShort": "Code - OSS",
+  "nameLong": "Code - OSS",
+  "applicationName": "code-oss",
+  "dataFolderName": ".vscode-oss",
+  "extensionsGallery": {
+    "serviceUrl": "https://marketplace.visualstudio.com/_apis/public/gallery",
+    "itemUrl": "https://marketplace.visualstudio.com/items"
+  },
+  "upstreamFixtureKey": "keep-me"
+}

--- a/scripts/fixtures/code-oss-dry-run/src/vs/workbench/workbench.common.main.ts
+++ b/scripts/fixtures/code-oss-dry-run/src/vs/workbench/workbench.common.main.ts
@@ -1,0 +1,1 @@
+import 'vs/workbench/contrib/files/browser/files.contribution';

--- a/tests/codeOssIntegrationDryRun.test.ts
+++ b/tests/codeOssIntegrationDryRun.test.ts
@@ -1,0 +1,96 @@
+import { execFile as execFileCallback } from 'node:child_process';
+import { access, cp, mkdtemp, readFile, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { describe, expect, it } from 'vitest';
+
+const execFile = promisify(execFileCallback);
+const root = process.cwd();
+
+async function exists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function findPowerShell(): Promise<string | undefined> {
+  for (const command of ['pwsh', 'powershell', 'powershell.exe']) {
+    try {
+      await execFile(command, ['-NoProfile', '-Command', '$PSVersionTable.PSVersion.ToString()']);
+      return command;
+    } catch {
+      // Try the next common executable name.
+    }
+  }
+
+  return undefined;
+}
+
+describe('Code - OSS integration dry-run reporting', () => {
+  it('records planned apply and rollback actions without mutating the target checkout', async () => {
+    const scriptPath = path.join(root, 'scripts', 'apply-gomi-code-oss-integration.ps1');
+    const fixturePath = path.join(root, 'scripts', 'fixtures', 'code-oss-dry-run');
+    const powerShell = await findPowerShell();
+
+    expect(await exists(fixturePath)).toBe(true);
+
+    if (!powerShell) {
+      const script = await readFile(scriptPath, 'utf8');
+      const windowsRelease = await readFile(path.join(root, 'docs', 'windows-release.md'), 'utf8');
+
+      expect(script).toContain('[string]$ReportPath');
+      expect(script).toContain('Write-GomiIntegrationReport');
+      expect(windowsRelease).toContain('-ReportPath');
+      expect(windowsRelease).toContain('dry-run report');
+      return;
+    }
+
+    const tempRoot = await mkdtemp(path.join(os.tmpdir(), 'gomi-code-oss-dry-run-'));
+    const codeOssRoot = path.join(tempRoot, 'code-oss');
+    const reportPath = path.join(tempRoot, 'reports', 'dry-run-report.json');
+    const productPath = path.join(codeOssRoot, 'product.json');
+    const workbenchPath = path.join(codeOssRoot, 'src', 'vs', 'workbench', 'workbench.common.main.ts');
+    const gomiTarget = path.join(codeOssRoot, 'src', 'vs', 'workbench', 'contrib', 'gomi');
+
+    try {
+      await cp(fixturePath, codeOssRoot, { recursive: true });
+
+      const beforeProduct = await readFile(productPath, 'utf8');
+      const beforeWorkbench = await readFile(workbenchPath, 'utf8');
+
+      await execFile(powerShell, [
+        '-NoProfile',
+        '-ExecutionPolicy',
+        'Bypass',
+        '-File',
+        scriptPath,
+        '-CodeOssRoot',
+        codeOssRoot,
+        '-DryRun',
+        '-ReportPath',
+        reportPath
+      ]);
+
+      expect(await readFile(productPath, 'utf8')).toBe(beforeProduct);
+      expect(await readFile(workbenchPath, 'utf8')).toBe(beforeWorkbench);
+      expect(await exists(gomiTarget)).toBe(false);
+
+      const report = JSON.parse(await readFile(reportPath, 'utf8')) as {
+        dryRun?: boolean;
+        actions?: Array<{ kind?: string; destination?: string }>;
+        rollbackActions?: unknown[];
+      };
+
+      expect(report.dryRun).toBe(true);
+      expect(report.actions?.some((action) => action.kind === 'merge-product-json')).toBe(true);
+      expect(report.actions?.some((action) => action.destination?.endsWith('src/vs/workbench/contrib/gomi'))).toBe(true);
+      expect(report.rollbackActions?.length).toBeGreaterThan(0);
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/releaseReadiness.test.ts
+++ b/tests/releaseReadiness.test.ts
@@ -258,6 +258,8 @@ describe('release readiness', () => {
     expect(windowsRelease).toContain('Bootstrap or update a Code - OSS checkout');
     expect(windowsRelease).toContain('Generate Gomi desktop branding assets');
     expect(windowsRelease).toContain('GitHub Releases do not present the prototype bundle as the final IDE');
+    expect(windowsRelease).toContain('-ReportPath');
+    expect(windowsRelease).toContain('dry-run report');
     expect(windowsRelease).toContain('End users should not run Gomi IDE with `npm run dev`.');
     expect(windowsRelease).toContain('Inno Setup `.exe` installer');
     expect(bootstrapScript).toContain("'clone', '--filter=blob:none'");
@@ -271,7 +273,7 @@ describe('release readiness', () => {
     expect(collectorScript).toContain('Product identity verified from Code - OSS product.json');
     expect(collectorScript).toContain('WINDOWS-SHA256SUMS.txt');
     expect(packageJson.scripts?.['verify:release']).toBe(
-      'vitest run tests/releaseReadiness.test.ts tests/codeOssIntegrationManifest.test.ts'
+      'vitest run tests/releaseReadiness.test.ts tests/codeOssIntegrationManifest.test.ts tests/codeOssIntegrationDryRun.test.ts'
     );
   });
 });


### PR DESCRIPTION
## Summary
- Adds a Code - OSS dry-run report path so `-DryRun -ReportPath` can write planned apply and rollback actions without mutating the target checkout.
- Rejects report paths inside the Code - OSS checkout to keep dry-run evidence outside the tree being validated.
- Adds fixture/test/docs coverage for the dry-run report flow and includes the dry-run test in release verification.

## Linked issue / bounty
- Fixes #25
- Refs mergeos-bounties/mergeos#244
- Issue pre-PR update: https://github.com/mergeos-bounties/Gomi/issues/25#issuecomment-4953078463

## Problem
The Code - OSS integration script had dry-run behavior, but it did not emit a structured report of the planned manifest application and rollback steps. That made it harder to validate a release candidate without touching a Code - OSS checkout or manually inspecting every planned operation.

## Fix
- Adds `-ReportPath` support to `scripts/apply-gomi-code-oss-integration.ps1` for dry-run report output.
- Records planned manifest apply actions and rollback actions in JSON.
- Preserves the existing dry-run no-write behavior and rejects report paths located under the target Code - OSS checkout.
- Adds a fixture-backed dry-run test, release-readiness wiring, and docs in `docs/windows-release.md`.

## Verification
QA approved commit `ce655320fd76c27bc36291862e311cbc0250fa02` with:
- `npm ci` passed.
- `npm run verify:release` passed.
- `npm run typecheck` passed.
- `git diff --check` passed.
- Prior patch validation also passed `npm run build` with the existing Vite large-chunk warning.
- Prior full test rerun from a real `Gomi` checkout passed: 28 files passed, 1 skipped; 138 tests passed, 3 skipped.
- PowerShell 7.4.2 dry-run acceptance passed: valid outside-checkout `-ReportPath` exited 0 and wrote JSON; `product.json` and workbench checksums stayed unchanged; the Gomi target stayed uncreated; the report contained 25 apply actions and 25 rollback actions; inside-checkout `ReportPath` rejection passed.
- GitHub commit attribution check passed: author and committer resolve to `Rajesh270712` with `102693488+Rajesh270712@users.noreply.github.com`.

## Public dry-run evidence
Gate 1 screenshot evidence is embedded below. These PNGs are hosted from a public evidence-only fork commit, separate from this PR's code branch: https://github.com/Rajesh270712/Gomi/tree/725a20686acf29204435cc204c4885e50e9cda89/gate1-evidence

![Gate 1 evidence summary](https://raw.githubusercontent.com/Rajesh270712/Gomi/725a20686acf29204435cc204c4885e50e9cda89/gate1-evidence/gomi-25-gate1-summary.png)

![PowerShell dry-run log screenshot](https://raw.githubusercontent.com/Rajesh270712/Gomi/725a20686acf29204435cc204c4885e50e9cda89/gate1-evidence/gomi-25-powershell-dry-run.png)

![Dry-run report and rejection screenshot](https://raw.githubusercontent.com/Rajesh270712/Gomi/725a20686acf29204435cc204c4885e50e9cda89/gate1-evidence/gomi-25-report-and-rejection.png)

Supporting text artifacts remain available here:
- Evidence bundle: https://gist.github.com/Rajesh270712/f2da7db085fad5c2853e5781e6cb2f76
- PowerShell 7.4.2 execution log: https://gist.githubusercontent.com/Rajesh270712/f2da7db085fad5c2853e5781e6cb2f76/raw/362d9554dfbff2778c73fa497807706bfd1dd925/powershell-dry-run-qa.log
- Generated dry-run report JSON: https://gist.githubusercontent.com/Rajesh270712/f2da7db085fad5c2853e5781e6cb2f76/raw/53d0425dfd916d11afe2081bbee885833d2a1ca7/dry-run-report.json
- Inside-checkout `-ReportPath` rejection log: https://gist.githubusercontent.com/Rajesh270712/f2da7db085fad5c2853e5781e6cb2f76/raw/6061d3143d2665f56f582bfecffab3a6b27eb61d/inside-report-rejection.log
- SHA-256 checksums: https://gist.githubusercontent.com/Rajesh270712/f2da7db085fad5c2853e5781e6cb2f76/raw/3bc25eb7db81c8ed059ffaa5c0d511b84ae0b6b1/checksums.sha256

The public evidence records the outside-checkout dry run writing JSON, before/after checksum matches for `product.json` and `src/vs/workbench/workbench.common.main.ts`, `src/vs/workbench/contrib/gomi` staying uncreated in the target fixture, 25 planned apply actions, 25 rollback actions, and rejection of a report path inside the Code - OSS checkout.

## Risk and rollback
Risk is limited to the Code - OSS integration script dry-run/report path plus the release verification test fixture. Reverting this PR removes the report-path support, fixture/docs updates, and release-readiness wiring, restoring the previous dry-run behavior.

## Maintainer attention
- The runtime dry-run evidence came from PowerShell 7.4.2 in a Linux container, not native Windows PowerShell.
- The dry-run report intentionally includes a generated webview asset missing warning as manifest evidence; dry-run still does not mutate the target checkout.
- Existing npm audit output reported 11 high-severity dependency findings; this PR does not change dependency versions.
