### PR TITLE
feat: streaming responses + throttle for agent providers (Fixes #10)

### DIFF
--- a/src/vs/workbench/contrib/gomi/common/gomiTypes.ts
+++ b/src/vs/workbench/contrib/gomi/common/gomiTypes.ts
@@ -273,6 +273,12 @@ export type GomiRuntimeEvent =
       task: GomiTask;
     }
   | {
+      type: 'agent_progress';
+      agentId: GomiAgentId;
+      taskId: string;
+      chunk: string;
+    }
+  | {
       type: 'agent_result';
       result: GomiAgentResult;
     }

--- a/src/vs/workbench/contrib/gomi/node/agentProvider.ts
+++ b/src/vs/workbench/contrib/gomi/node/agentProvider.ts
@@ -67,6 +67,14 @@ export interface GomiAgentRunContext {
   };
   signal?: AbortSignal;
   reportProgress?: (update: GomiAgentProgressUpdate) => void;
+  /**
+   * Optional progress sink. Providers that support incremental output (CLI
+   * stdout, HTTP streaming) should call this with raw text chunks as they
+   * arrive so the caller can surface live progress in the Office UI.
+   * Providers without incremental output (demo, non-streaming HTTP) may
+   * simply omit calling it — runAgentTask must still resolve normally.
+   */
+  onChunk?: (chunk: string) => void;
 }
 
 export interface GomiAgentProvider {

--- a/src/vs/workbench/contrib/gomi/node/agentRuntime.ts
+++ b/src/vs/workbench/contrib/gomi/node/agentRuntime.ts
@@ -457,7 +457,15 @@ export class GomiAgentRuntime {
               patchApprovalRequired: this.officeSettings.memory.requirePatchApproval
             },
             signal,
-            reportProgress: (update) => queueProgressUpdate(task, update)
+            reportProgress: (update) => queueProgressUpdate(task, update),
+            onChunk: (chunk) => {
+              this.bus.publish({
+                type: 'agent_progress',
+                agentId: task.agentId,
+                taskId: task.id,
+                chunk
+              });
+            }
           }).then((result) => ({
             id: runId,
             task,

--- a/src/vs/workbench/contrib/gomi/node/cliAgentProvider.ts
+++ b/src/vs/workbench/contrib/gomi/node/cliAgentProvider.ts
@@ -22,6 +22,7 @@ import {
   type GomiAgentResponse,
   type GomiAgentRunContext
 } from './agentProvider';
+import { createStreamThrottle } from './streamThrottle';
 
 export interface GomiCliCommandInvocation {
   executable: string;
@@ -44,7 +45,8 @@ export interface GomiCliCommandResult {
 
 export type GomiCliCommandRunner = (
   invocation: GomiCliCommandInvocation,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  throttle?: { push: (chunk: string) => void }
 ) => Promise<GomiCliCommandResult>;
 
 export interface NodeCliGomiAgentProviderOptions {
@@ -61,7 +63,7 @@ export class NodeCliGomiAgentProvider implements GomiAgentProvider {
   readonly label = 'Node CLI Agent Router';
   readonly kind = 'cli';
   readonly capabilities = {
-    streaming: false,
+    streaming: true,
     tools: true,
     maxContextTokens: 64000
   };
@@ -119,6 +121,13 @@ export class NodeCliGomiAgentProvider implements GomiAgentProvider {
       );
     }
 
+    const throttle = context.onChunk
+      ? createStreamThrottle({
+          intervalMs: 120,
+          onFlush: (payload) => context.onChunk?.(payload)
+        })
+      : undefined;
+
     const providerLabel = context.agentCli?.label ?? provider?.label ?? providerId;
     const result = await this.runCliCommand({
       executable,
@@ -130,7 +139,9 @@ export class NodeCliGomiAgentProvider implements GomiAgentProvider {
       taskId: context.task.id,
       cwd: this.cwd,
       timeoutMs: this.timeoutMs
-    }, context.signal);
+    }, context.signal, throttle);
+
+    throttle?.dispose();
 
     if (result.timedOut) {
       return this.createConfigurationErrorResult(
@@ -158,10 +169,11 @@ export class NodeCliGomiAgentProvider implements GomiAgentProvider {
 
   private async runCliCommand(
     invocation: GomiCliCommandInvocation,
-    signal?: AbortSignal
+    signal?: AbortSignal,
+    throttle?: { push: (chunk: string) => void }
   ): Promise<GomiCliCommandResult> {
     try {
-      return await this.commandRunner(invocation, signal);
+      return await this.commandRunner(invocation, signal, throttle);
     } catch (error) {
       return {
         stdout: '',
@@ -215,7 +227,8 @@ const MAX_CLI_OUTPUT_BYTES = 10_000_000;
 
 export async function spawnGomiCliCommand(
   invocation: GomiCliCommandInvocation,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  throttle?: { push: (chunk: string) => void }
 ): Promise<GomiCliCommandResult> {
   return new Promise((resolve) => {
     const child = spawn(invocation.executable, invocation.args, {
@@ -267,7 +280,9 @@ export async function spawnGomiCliCommand(
         return;
       }
 
-      stdout += chunk.toString('utf8');
+      const text = chunk.toString('utf8');
+      stdout += text;
+      throttle?.push(text);
     });
     child.stderr.on('data', (chunk: Buffer) => {
       if (stderr.length >= MAX_CLI_OUTPUT_BYTES) {

--- a/src/vs/workbench/contrib/gomi/node/streamThrottle.ts
+++ b/src/vs/workbench/contrib/gomi/node/streamThrottle.ts
@@ -1,0 +1,91 @@
+/**
+ * StreamThrottle coalesces high-frequency streaming chunks into a bounded
+ * number of flushes so live agent output can be surfaced to the Office UI
+ * without flooding it with an update per byte.
+ *
+ * - The first chunk flushes immediately (so streaming "feels live").
+ * - Subsequent chunks that arrive within `intervalMs` of the last flush are
+ *   buffered and released on a trailing flush.
+ * - `dispose()` flushes any remaining buffered content (called when a task
+ *   completes) so no trailing output is lost.
+ */
+export interface StreamThrottleOptions {
+  /** Minimum time between flushes, in milliseconds. */
+  intervalMs: number;
+  /** Invoked with the accumulated payload on each flush. */
+  onFlush: (payload: string) => void;
+  /** Injectable clock for deterministic testing. Defaults to Date.now. */
+  now?: () => number;
+}
+
+export class StreamThrottle {
+  private buffer = '';
+  private lastFlush = Number.NEGATIVE_INFINITY;
+  private timer: ReturnType<typeof setTimeout> | undefined;
+  private disposed = false;
+  private readonly intervalMs: number;
+  private readonly now: () => number;
+  private readonly onFlush: (payload: string) => void;
+
+  constructor(options: StreamThrottleOptions) {
+    this.intervalMs = Math.max(0, options.intervalMs);
+    this.onFlush = options.onFlush;
+    this.now = options.now ?? (() => Date.now());
+  }
+
+  /** Queue a chunk. Flushes immediately if the throttle window has elapsed. */
+  push(chunk: string): void {
+    if (this.disposed || chunk.length === 0) {
+      return;
+    }
+
+    this.buffer += chunk;
+    const elapsed = this.now() - this.lastFlush;
+
+    if (elapsed >= this.intervalMs) {
+      this.flush();
+      return;
+    }
+
+    if (this.timer === undefined) {
+      const remaining = Math.max(0, this.intervalMs - elapsed);
+      this.timer = globalThis.setTimeout(() => this.flush(), remaining);
+    }
+  }
+
+  /** Emit any buffered content now and reset the throttle window. */
+  flush(): void {
+    if (this.timer !== undefined) {
+      globalThis.clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+
+    if (this.buffer.length === 0) {
+      return;
+    }
+
+    const payload = this.buffer;
+    this.buffer = '';
+    this.lastFlush = this.now();
+    this.onFlush(payload);
+  }
+
+  /** Flush remaining content and stop accepting further chunks. */
+  dispose(): void {
+    if (this.disposed) {
+      return;
+    }
+
+    this.flush();
+    this.disposed = true;
+
+    if (this.timer !== undefined) {
+      globalThis.clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+  }
+}
+
+export function createStreamThrottle(options: StreamThrottleOptions): StreamThrottle {
+  return new StreamThrottle(options);
+}

--- a/tests/cliAgentProvider.test.ts
+++ b/tests/cliAgentProvider.test.ts
@@ -129,6 +129,53 @@ describe('Node CLI agent provider', () => {
     );
     expect(designerSummaries).toContain('designer via Gemini CLI');
   });
+
+  it('streams CLI stdout chunks via onChunk when enabled', async () => {
+    const chunks: string[] = [];
+    const provider = createNodeCliGomiAgentProvider({
+      enabled: true,
+      commandRunner: async (invocation, _signal, throttle) => {
+        throttle?.push('line-1\n');
+        throttle?.push('line-2\n');
+        throttle?.push('line-3\n');
+
+        return {
+          stdout: 'line-1\nline-2\nline-3\n',
+          stderr: '',
+          exitCode: 0
+        };
+      }
+    });
+
+    expect(provider.capabilities.streaming).toBe(true);
+
+    const result = await provider.runAgentTask({
+      ...createRunContext('backend', 'codex'),
+      onChunk: (chunk) => chunks.push(chunk)
+    });
+
+    expect(result.summary.length).toBeGreaterThan(0);
+    expect(chunks.join('')).toBe('line-1\nline-2\nline-3\n');
+  });
+
+  it('does not throw when onChunk is omitted', async () => {
+    const provider = createNodeCliGomiAgentProvider({
+      enabled: true,
+      commandRunner: async (_invocation, _signal, throttle) => {
+        throttle?.push('partial output\n');
+
+        return {
+          stdout: 'final result',
+          stderr: '',
+          exitCode: 0
+        };
+      }
+    });
+
+    await expect(
+      provider.runAgentTask(createRunContext('backend', 'codex'))
+    ).resolves.toMatchObject({ agentId: 'backend' });
+  });
 });
 
 function createRunContext(agentId: GomiAgentId, command: string): GomiAgentRunContext {

--- a/tests/streamThrottle.test.ts
+++ b/tests/streamThrottle.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createStreamThrottle } from '../src/vs/workbench/contrib/gomi/node/streamThrottle';
+
+describe('StreamThrottle', () => {
+  let onFlush: ReturnType<typeof vi.fn>;
+  let now: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    onFlush = vi.fn();
+    now = vi.fn(() => 0);
+  });
+
+  it('flushes first chunk immediately', () => {
+    const throttle = createStreamThrottle({
+      intervalMs: 100,
+      onFlush,
+      now
+    });
+
+    throttle.push('chunk1');
+
+    expect(onFlush).toHaveBeenCalledOnce();
+    expect(onFlush).toHaveBeenCalledWith('chunk1');
+  });
+
+  it('buffers chunks within interval window', () => {
+    const throttle = createStreamThrottle({
+      intervalMs: 100,
+      onFlush,
+      now
+    });
+
+    throttle.push('chunk1');
+    now.mockReturnValue(50); // 50ms elapsed
+    throttle.push('chunk2');
+    throttle.push('chunk3');
+
+    // Only first chunk flushed, rest buffered
+    expect(onFlush).toHaveBeenCalledOnce();
+    expect(onFlush).toHaveBeenCalledWith('chunk1');
+  });
+
+  it('flushes buffer when interval elapses', () => {
+    const throttle = createStreamThrottle({
+      intervalMs: 100,
+      onFlush,
+      now
+    });
+
+    throttle.push('chunk1');
+    now.mockReturnValue(50);
+    throttle.push('chunk2');
+
+    // Simulate timeout callback
+    now.mockReturnValue(100);
+    throttle.flush();
+
+    expect(onFlush).toHaveBeenCalledTimes(2);
+    expect(onFlush).toHaveBeenNthCalledWith(1, 'chunk1');
+    expect(onFlush).toHaveBeenNthCalledWith(2, 'chunk2');
+  });
+
+  it('flushes remaining buffer on dispose', () => {
+    const throttle = createStreamThrottle({
+      intervalMs: 100,
+      onFlush,
+      now
+    });
+
+    throttle.push('chunk1');
+    now.mockReturnValue(50);
+    throttle.push('chunk2');
+    throttle.push('chunk3');
+
+    throttle.dispose();
+
+    expect(onFlush).toHaveBeenCalledTimes(2);
+    expect(onFlush).toHaveBeenNthCalledWith(2, 'chunk2chunk3');
+  });
+
+  it('ignores pushes after dispose', () => {
+    const throttle = createStreamThrottle({
+      intervalMs: 100,
+      onFlush,
+      now
+    });
+
+    throttle.push('chunk1');
+    throttle.dispose();
+    throttle.push('chunk2');
+
+    expect(onFlush).toHaveBeenCalledOnce();
+    expect(onFlush).toHaveBeenCalledWith('chunk1');
+  });
+
+  it('ignores empty chunks', () => {
+    const throttle = createStreamThrottle({
+      intervalMs: 100,
+      onFlush,
+      now
+    });
+
+    throttle.push('chunk1');
+    throttle.push('');
+    throttle.push('');
+
+    expect(onFlush).toHaveBeenCalledOnce();
+    expect(onFlush).toHaveBeenCalledWith('chunk1');
+  });
+
+  it('coalesces multiple buffered chunks into single flush', () => {
+    const throttle = createStreamThrottle({
+      intervalMs: 100,
+      onFlush,
+      now
+    });
+
+    throttle.push('a');
+    now.mockReturnValue(50);
+    throttle.push('b');
+    throttle.push('c');
+    throttle.push('d');
+    now.mockReturnValue(100);
+    throttle.flush();
+
+    expect(onFlush).toHaveBeenNthCalledWith(2, 'bcd');
+  });
+
+  it('does not call onFlush for empty buffer on dispose', () => {
+    const throttle = createStreamThrottle({
+      intervalMs: 100,
+      onFlush,
+      now
+    });
+
+    throttle.dispose();
+
+    expect(onFlush).not.toHaveBeenCalled();
+  });
+
+  it('respects negative interval as zero', () => {
+    const throttle = createStreamThrottle({
+      intervalMs: -50,
+      onFlush,
+      now
+    });
+
+    throttle.push('chunk1');
+    now.mockReturnValue(1);
+    throttle.push('chunk2');
+
+    // Second push should flush immediately because interval is 0
+    expect(onFlush).toHaveBeenCalledTimes(2);
+    expect(onFlush).toHaveBeenNthCalledWith(2, 'chunk2');
+  });
+});


### PR DESCRIPTION
## Summary

Implements streaming responses for Gomi agent providers with output throttling to keep the Office UI responsive during long CLI/HTTP agent runs.

## Changes
- **`streamThrottle.ts`** — new utility that coalesces high-frequency stdout chunks into a bounded number of flushes. First chunk flushes immediately (feels live), subsequent chunks within the throttle window are buffered and released on a trailing flush. `dispose()` flushes any remaining buffer so no trailing output is lost.
- **`GomiAgentRunContext.onChunk`** — optional progress sink. Providers that support incremental output (CLI stdout, HTTP streaming) call it with raw text chunks. Providers without it simply omit calling — `runAgentTask` still resolves normally.
- **`agent_progress` runtime event** — emitted by `GomiAgentRuntime` so the UI can render live agent output per task.
- **CLI provider** — wires stdout chunks through the throttle to `onChunk`; `capabilities.streaming` now `true`.

## Testing
- `tests/streamThrottle.test.ts` — 9 tests: immediate first flush, buffering within window, trailing flush, dispose flush, post-dispose no-op, empty-chunk skip, coalescing, negative interval.
- `tests/cliAgentProvider.test.ts` — 2 new tests: streams stdout chunks via onChunk, does not throw when onChunk omitted.
- `npx tsc --noEmit` clean. Full suite: 147 passed (1 pre-existing env-specific failure in nodeWorkspaceReader unrelated to this change).

Ready for review.