### PR TITLE
feat: add Playwright smoke e2e tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,15 @@ npm run electron:start
 # or: npm run desktop:build   # NSIS installer under release/desktop/
 ```
 
+End-to-end tests (Playwright, headless Chromium):
+
+```bash
+npx playwright install chromium   # one-time browser download
+npm run test:e2e                  # runs e2e/ specs against Vite dev server
+```
+
+The `test:e2e` script starts the Vite dev server automatically (or reuses a running one on port 5173). Tests cover app startup, a full demo CEO session, and layout mode toggling.
+
 Quality gate (matches CI):
 
 ```bash

--- a/e2e/app-loads.spec.ts
+++ b/e2e/app-loads.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from 'playwright/test';
+
+test.describe('App loads and shows critical UI', () => {
+  test('displays core UI elements on startup', async ({ page }) => {
+    await page.goto('/');
+
+    // Run CEO button is visible
+    const runButton = page.getByTestId('run-ceo-button');
+    await expect(runButton).toBeVisible();
+    await expect(runButton).toHaveText(/Run CEO/);
+
+    // Textarea has the sample request text pre-filled
+    const textarea = page.getByTestId('request-textarea');
+    await expect(textarea).toBeVisible();
+    await expect(textarea).not.toHaveValue('');
+
+    // Status bar shows "Ready"
+    const statusBar = page.getByTestId('status-bar');
+    await expect(statusBar).toBeVisible();
+    await expect(statusBar).toHaveText(/Ready/);
+
+    // At least one agent row is visible in the right panel
+    const agentRows = page.getByTestId('agent-row');
+    await expect(agentRows.first()).toBeVisible();
+  });
+});

--- a/e2e/demo-session.spec.ts
+++ b/e2e/demo-session.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from 'playwright/test';
+
+test.describe('Run demo session', () => {
+  test('completes a full CEO demo run', async ({ page }) => {
+    await page.goto('/');
+
+    // Wait for the app to be ready
+    const runButton = page.getByTestId('run-ceo-button');
+    await expect(runButton).toBeVisible();
+
+    // Status bar starts at "Ready"
+    const statusBar = page.getByTestId('status-bar');
+    await expect(statusBar).toHaveText(/Ready/);
+
+    // Click Run CEO
+    await runButton.click();
+
+    // Status bar should change to "Agents working"
+    await expect(statusBar).toHaveText(/Agents working/);
+
+    // Wait for session to complete — status bar returns to "Ready"
+    // Demo runtime uses 360ms delays, total ~5-8s
+    await expect(statusBar).toHaveText(/Ready/, { timeout: 20_000 });
+
+    // At least one chat message appeared
+    const chatMessages = page.getByTestId('chat-message');
+    await expect(chatMessages.first()).toBeVisible();
+
+    // Final report section has content (not just "Waiting for report.")
+    const finalReport = page.getByTestId('final-report');
+    await expect(finalReport).toBeVisible();
+    await expect(finalReport).not.toHaveText(/Waiting for report/);
+  });
+});

--- a/e2e/layout-toggle.spec.ts
+++ b/e2e/layout-toggle.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from 'playwright/test';
+
+test.describe('Layout mode toggle', () => {
+  test('toggles full office layout class on and off', async ({ page }) => {
+    await page.goto('/');
+
+    const shell = page.getByTestId('gomi-shell');
+    await expect(shell).toBeVisible();
+
+    // Shell should not have full-office class initially (standard mode)
+    await expect(shell).not.toHaveClass(/is-full-office/);
+
+    // Click "Full office layout" button
+    const layoutGroup = page.getByTestId('layout-mode-group');
+    const fullOfficeButton = layoutGroup.getByRole('button', { name: 'Full office layout' });
+    await fullOfficeButton.click();
+
+    // Shell gains the is-full-office class
+    await expect(shell).toHaveClass(/is-full-office/);
+
+    // Click "Standard office layout" to revert
+    const standardButton = layoutGroup.getByRole('button', { name: 'Standard office layout' });
+    await standardButton.click();
+
+    // Class removed
+    await expect(shell).not.toHaveClass(/is-full-office/);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "generate:brand-assets": "node scripts/generate-gomi-brand-assets.mjs",
     "preview": "vite preview --host 127.0.0.1",
     "test": "vitest run",
+    "test:e2e": "npx playwright test",
     "typecheck": "tsc -b",
     "verify:release": "vitest run tests/releaseReadiness.test.ts tests/codeOssIntegrationManifest.test.ts tests/codeOssIntegrationDryRun.test.ts",
     "electron:start": "electron .",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'playwright/test';
+
+export default defineConfig({
+  testDir: 'e2e',
+  timeout: 30_000,
+  use: {
+    baseURL: 'http://127.0.0.1:5173',
+    headless: true,
+    browserName: 'chromium',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { browserName: 'chromium' },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    port: 5173,
+    reuseExistingServer: true,
+  },
+});

--- a/src/vs/workbench/contrib/gomi/browser/GomiOfficeApp.tsx
+++ b/src/vs/workbench/contrib/gomi/browser/GomiOfficeApp.tsx
@@ -651,7 +651,7 @@ export function GomiOfficeApp() {
   }
 
   return (
-    <div className={shellClassName}>
+    <div className={shellClassName} data-testid="gomi-shell">
       <header className="gomi-titlebar">
         <div className="gomi-titlebar__brand">
           <span className="gomi-logo">G</span>
@@ -705,7 +705,7 @@ export function GomiOfficeApp() {
               >
                 {effectiveRightPanelCollapsed ? <PanelRightOpen size={18} /> : <PanelRightClose size={18} />}
               </button>
-              <div className="gomi-view-mode-controls" role="group" aria-label="Office layout mode">
+              <div className="gomi-view-mode-controls" role="group" aria-label="Office layout mode" data-testid="layout-mode-group">
                 {officeViewModes.map(({ id, label, Icon }) => (
                   <button
                     className={`gomi-icon-button ${officeViewMode === id ? 'is-active' : ''}`}
@@ -726,10 +726,11 @@ export function GomiOfficeApp() {
               value={request}
               onChange={(event) => setRequest(event.target.value)}
               aria-label="Project Request"
+              data-testid="request-textarea"
               spellCheck={false}
             />
             <div className="gomi-request-actions">
-              <button className="gomi-send" onClick={runOfficeSession} disabled={isRunning}>
+              <button className="gomi-send" onClick={runOfficeSession} disabled={isRunning} data-testid="run-ceo-button">
                 <Send size={17} />
                 <span>{isRunning ? 'Running' : 'Run CEO'}</span>
               </button>
@@ -804,7 +805,7 @@ export function GomiOfficeApp() {
         />
       </div>
 
-      <footer className="gomi-statusbar">
+      <footer className="gomi-statusbar" data-testid="status-bar">
         <span>{workbenchBridge ? 'Gomi Workbench Bridge' : 'Gomi Demo Runtime'}</span>
         <span>{isRunning ? 'Agents working' : 'Ready'}</span>
       </footer>
@@ -1032,7 +1033,7 @@ function AgentRow({ agent }: { agent: GomiAgent }) {
   const Icon = agent.status === 'sleeping' ? Bed : iconForAgent(agent.id);
 
   return (
-    <div className="gomi-agent-row">
+    <div className="gomi-agent-row" data-testid="agent-row">
       <div className="gomi-agent-avatar">
         <Icon size={17} />
       </div>
@@ -1143,7 +1144,7 @@ function OfficeSettingsPanel({
   ].filter(Boolean);
 
   return (
-    <section className="gomi-settings-panel" aria-label="Office Settings">
+    <section className="gomi-settings-panel" aria-label="Office Settings" data-testid="settings-panel">
       <div className="gomi-panel-header">
         <span>Office Settings</span>
         <Settings size={16} />
@@ -1535,7 +1536,7 @@ function ChatLog({ messages }: { messages: GomiChatMessage[] }) {
           <div className="gomi-report-empty">No messages yet.</div>
         ) : (
           messages.map((message) => (
-            <div className="gomi-message" key={message.id}>
+            <div className="gomi-message" key={message.id} data-testid="chat-message">
               <div className="gomi-message__head">
                 <span>
                   {message.senderName}
@@ -1568,7 +1569,7 @@ function FinalReport({
   nativePreviewRequired: boolean;
 }) {
   return (
-    <div className="gomi-report">
+    <div className="gomi-report" data-testid="final-report">
       <div className="gomi-panel-header">
         <span>Final Report</span>
         <ClipboardList size={16} />

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}


### PR DESCRIPTION
Fixes #13

Adds Playwright smoke e2e tests for the Gomi Office prototype.

**What's included:**
- `playwright.config.ts` — headless Chromium, auto-starts dev server on port 5173
- 3 smoke specs in `e2e/`:
  - `app-loads.spec.ts` — verifies critical UI renders (run button, textarea, status bar, agent rows)
  - `demo-session.spec.ts` — runs CEO demo, verifies completion + chat output + final report
  - `layout-toggle.spec.ts` — toggles full/standard layout, verifies CSS class changes
- 9 `data-testid` attributes added to `GomiOfficeApp.tsx` for stable selectors
- `test:e2e` script in `package.json`
- E2e section added to `README.md`

**All waits use Playwright auto-retry assertions — zero `waitForTimeout` calls.**

3/3 specs pass headless on Windows (11s total).

/claim #13