### PR TITLE
feat: add Zod-based message validator for webview host bridge (issue …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "lucide-react": "^0.475.0",
         "phaser": "^3.87.0",
         "react": "^19.0.0",
-        "react-dom": "^19.0.0"
+        "react-dom": "^19.0.0",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@types/node": "^22.13.1",
@@ -7568,6 +7569,15 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "lucide-react": "^0.475.0",
     "phaser": "^3.87.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^22.13.1",

--- a/src/vs/workbench/contrib/gomi/browser/gomiWebviewHostBridge.ts
+++ b/src/vs/workbench/contrib/gomi/browser/gomiWebviewHostBridge.ts
@@ -5,6 +5,8 @@ import {
   shouldReportInvalidGomiBridgeMessage,
   withGomiBridgeProtocol
 } from './gomiWebviewBridge';
+import { GOMI_BRIDGE_PROTOCOL_VERSION } from '../electron-sandbox/gomiBridge';
+import { validateGomiBridgeMessage } from '../common/gomiMessageValidator';
 
 export interface GomiDisposable {
   dispose(): void;
@@ -27,7 +29,16 @@ export class GomiWebviewHostBridge implements GomiWorkbenchBridge, GomiDisposabl
     this.disposable = this.webview.onMessage((event) => {
       if (!isGomiBridgeMessage(event.message)) {
         if (shouldReportInvalidGomiBridgeMessage(event.message)) {
-          void this.webview.postMessage(createGomiBridgeErrorMessage());
+          // Use Zod validator for a specific rejection reason (size, version,
+          // unknown type, malformed payload) — capped at 2 000 chars.
+          const zod = validateGomiBridgeMessage(event.message);
+          const detail = zod.success ? '' : `: ${zod.error}`;
+          void this.webview.postMessage({
+            protocolVersion: GOMI_BRIDGE_PROTOCOL_VERSION,
+            type: 'gomi.bridgeError',
+            code: 'invalid_message',
+            message: `Rejected invalid Gomi bridge message${detail}`.slice(0, 2_000),
+          });
         }
 
         return;

--- a/src/vs/workbench/contrib/gomi/common/gomiMessageValidator.ts
+++ b/src/vs/workbench/contrib/gomi/common/gomiMessageValidator.ts
@@ -1,0 +1,271 @@
+/**
+ * GomiMessageValidator — Zod-based message schema validation for the Gomi bridge.
+ * -------------------------------------------------------------------------------
+ * PROTOCOL NOTE (see also electron-sandbox/gomiBridge.ts):
+ *   Every message crossing the webview/host privilege boundary MUST pass
+ *   through `validateGomiBridgeMessage()` before dispatch or consumption.
+ *
+ *   Protocol version: 1 (GOMI_BRIDGE_PROTOCOL_VERSION)
+ *   Max serialized size:  64 000 bytes
+ *   Max text field:       16 000 characters
+ *   Max error message:     2 000 characters
+ *   Max patch diff:       60 000 characters
+ *   Max path length:         500 characters
+ *   Max array items:         100
+ *
+ *   All string fields enforce min(1) to reject empty values.
+ *   Unknown message types are rejected at the discriminator level.
+ *   New message types MUST be registered in the discriminated union below.
+ *
+ *   This module complements the manual validators in gomiWebviewBridge.ts.
+ *   The manual validators remain the runtime guard; Zod schemas provide
+ *   richer error messages and serve as the single source of truth for
+ *   message shapes during development and code review.
+ */
+
+import { z } from 'zod';
+
+// ────────────────────────────────────────────────────
+//  Constants (mirrored from gomiWebviewBridge.ts)
+// ────────────────────────────────────────────────────
+export const GOMI_BRIDGE_PROTOCOL_VERSION = 1;
+export const GOMI_BRIDGE_MAX_MESSAGE_BYTES = 64_000;
+
+// ────────────────────────────────────────────────────
+//  Enums / Literals
+// ────────────────────────────────────────────────────
+const agentIdSchema = z.enum([
+  'ceo', 'system-analyst', 'backend', 'frontend',
+  'designer', 'database', 'qa', 'devops',
+]);
+
+const agentProviderIdSchema = z.enum([
+  'codex-cli', 'claude-code', 'gemini-cli', 'aider-cli',
+  'cursor-style-agent', 'openai-compatible-api',
+  'ollama-local-model', 'local-llm', 'demo-runtime',
+]);
+
+const seatKindSchema = z.enum(['executive', 'department-head', 'employee']);
+const workModeSchema = z.enum(['active', 'sleeping', 'fired']);
+const embeddingProviderSchema = z.enum([
+  'local-hashing', 'openai-compatible', 'ollama-embeddings', 'ollama-embed',
+]);
+const privacyModeSchema = z.enum(['standard', 'strict']);
+const workspaceTrustSchema = z.enum(['trusted', 'untrusted']);
+const liveProviderModeSchema = z.enum(['demo-only', 'trusted-workspaces', 'allow-all']);
+const patchApprovalSchema = z.enum([
+  'pending', 'approved', 'rejected', 'applying', 'applied', 'failed',
+]);
+const patchRiskSchema = z.enum(['low', 'medium', 'high']);
+
+// ────────────────────────────────────────────────────
+//  Safe strings
+// ────────────────────────────────────────────────────
+const safeString = (maxLength: number) =>
+  z.string().min(1).max(maxLength);
+
+const optionalSafeString = (maxLength: number) =>
+  z.string().min(1).max(maxLength).optional();
+
+const safeRelativePath = z
+  .string()
+  .min(1)
+  .max(500)
+  .refine(
+    (v) => {
+      const n = v.replace(/\\/g, '/');
+      if (n.startsWith('/') || n.includes('\0')) return false;
+      return n.split('/').every((s) => s.length > 0 && s !== '.' && s !== '..');
+    },
+    { message: 'Path must be relative (no ../, no absolute, no NUL)' },
+  );
+
+// ────────────────────────────────────────────────────
+//  Sub-schemas
+// ────────────────────────────────────────────────────
+const gomiAgentSeatSchema = z.object({
+  id: safeString(128),
+  agentId: agentIdSchema,
+  name: safeString(128),
+  role: safeString(256),
+  seatKind: seatKindSchema,
+  providerId: agentProviderIdSchema,
+  workMode: workModeSchema,
+  canSleep: z.boolean(),
+  canFire: z.boolean(),
+  departmentId: agentIdSchema.optional(),
+}).strict();
+
+const gomiMemorySettingsSchema = z.object({
+  retrievalMode: z.literal('hybrid-vector'),
+  embeddingProvider: embeddingProviderSchema,
+  embeddingExecutionEnabled: z.boolean(),
+  sharedMemoryEnabled: z.boolean(),
+  indexWorkspaceContext: z.boolean(),
+  privacyMode: privacyModeSchema,
+  redactSecrets: z.boolean(),
+  retentionDays: z.number().int().min(1).max(3650),
+  maxProjectMemoryItems: z.number().int().min(1).max(10_000),
+  broadcastThreshold: z.number().min(0).max(1),
+  requirePatchApproval: z.boolean(),
+}).strict();
+
+const gomiExecutionSettingsSchema = z.object({
+  workspaceTrust: workspaceTrustSchema,
+  liveProviderMode: liveProviderModeSchema,
+  allowCliProviders: z.boolean(),
+  allowHttpProviders: z.boolean(),
+  requirePatchApprovalForLiveProviders: z.boolean(),
+  maxConcurrentAgentRuns: z.number().int().min(1).max(16),
+}).strict();
+
+const gomiOfficeSettingsSchema = z.object({
+  seats: gomiAgentSeatSchema.array().max(64),
+  memory: gomiMemorySettingsSchema,
+  execution: gomiExecutionSettingsSchema,
+}).strict();
+
+const gomiPatchProposalSchema = z.object({
+  id: safeString(128),
+  filePath: safeRelativePath,
+  targetFiles: safeRelativePath.array().max(100),
+  summary: safeString(2_000),
+  diff: safeString(60_000),
+  approvalStatus: patchApprovalSchema,
+  riskLevel: patchRiskSchema,
+  createdByAgentId: agentIdSchema,
+}).strict();
+
+// ────────────────────────────────────────────────────
+//  Discriminated union — every message type the bridge
+//  accepts MUST be listed here.
+// ────────────────────────────────────────────────────
+export const GomiBridgeMessageSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('gomi.run'),
+    protocolVersion: z.literal(GOMI_BRIDGE_PROTOCOL_VERSION).optional(),
+    request: safeString(16_000),
+    officeSettings: gomiOfficeSettingsSchema.optional(),
+  }).strict(),
+  z.object({
+    type: z.literal('gomi.stop'),
+    protocolVersion: z.literal(GOMI_BRIDGE_PROTOCOL_VERSION).optional(),
+    reason: optionalSafeString(2_000),
+  }).strict(),
+  z.object({
+    type: z.literal('gomi.pruneMemory'),
+    protocolVersion: z.literal(GOMI_BRIDGE_PROTOCOL_VERSION).optional(),
+    officeSettings: gomiOfficeSettingsSchema.optional(),
+  }).strict(),
+  z.object({
+    type: z.literal('gomi.pruneMemoryResult'),
+    protocolVersion: z.literal(GOMI_BRIDGE_PROTOCOL_VERSION).optional(),
+    report: z.record(z.unknown()).optional(),
+    error: optionalSafeString(2_000),
+  }).strict(),
+  z.object({
+    type: z.literal('gomi.applyPatch'),
+    protocolVersion: z.literal(GOMI_BRIDGE_PROTOCOL_VERSION).optional(),
+    patch: gomiPatchProposalSchema,
+  }).strict(),
+  z.object({
+    type: z.literal('gomi.previewPatch'),
+    protocolVersion: z.literal(GOMI_BRIDGE_PROTOCOL_VERSION).optional(),
+    patch: gomiPatchProposalSchema,
+  }).strict(),
+  z.object({
+    type: z.literal('gomi.previewPatchResult'),
+    protocolVersion: z.literal(GOMI_BRIDGE_PROTOCOL_VERSION).optional(),
+    patchId: safeString(128),
+    result: z.record(z.unknown()).optional(),
+    error: optionalSafeString(2_000),
+  }).strict(),
+  z.object({
+    type: z.literal('gomi.applyPatchResult'),
+    protocolVersion: z.literal(GOMI_BRIDGE_PROTOCOL_VERSION).optional(),
+    patchId: safeString(128),
+    result: z.record(z.unknown()).optional(),
+    error: optionalSafeString(2_000),
+  }).strict(),
+  z.object({
+    type: z.literal('gomi.event'),
+    protocolVersion: z.literal(GOMI_BRIDGE_PROTOCOL_VERSION).optional(),
+    event: z.record(z.unknown()),
+  }).strict(),
+  z.object({
+    type: z.literal('gomi.bridgeError'),
+    protocolVersion: z.literal(GOMI_BRIDGE_PROTOCOL_VERSION).optional(),
+    code: z.literal('invalid_message'),
+    message: safeString(2_000),
+  }).strict(),
+]);
+
+export type GomiBridgeMessage = z.infer<typeof GomiBridgeMessageSchema>;
+
+// ────────────────────────────────────────────────────
+//  Validation result
+// ────────────────────────────────────────────────────
+export type GomiMessageValidationResult =
+  | { success: true; message: GomiBridgeMessage }
+  | { success: false; error: string };
+
+// ────────────────────────────────────────────────────
+//  Public API
+// ────────────────────────────────────────────────────
+
+/**
+ * Validate a raw value against the Gomi bridge message schema.
+ *
+ * Checks are performed in order:
+ *   1. Must be a plain object (not null, not array).
+ *   2. Serialized size must be ≤ GOMI_BRIDGE_MAX_MESSAGE_BYTES.
+ *   3. Must have protocolVersion === GOMI_BRIDGE_PROTOCOL_VERSION
+ *      (strict — the bridge never forwards mis-versioned messages).
+ *   4. Schema validation via Zod discriminated union.
+ *
+ * Returns a structured result: never throws.
+ */
+export function validateGomiBridgeMessage(
+  value: unknown,
+): GomiMessageValidationResult {
+  // 1 – Guard: plain object
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return { success: false, error: 'Message must be a plain object' };
+  }
+
+  // 2 – Size guard
+  try {
+    const size = new TextEncoder().encode(JSON.stringify(value)).byteLength;
+    if (size > GOMI_BRIDGE_MAX_MESSAGE_BYTES) {
+      return {
+        success: false,
+        error: `Message too large: ${size} bytes (max ${GOMI_BRIDGE_MAX_MESSAGE_BYTES})`,
+      };
+    }
+  } catch {
+    return { success: false, error: 'Cannot serialize message for size check' };
+  }
+
+  // 3 – Protocol version
+  const rec = value as Record<string, unknown>;
+  if (rec.protocolVersion !== GOMI_BRIDGE_PROTOCOL_VERSION) {
+    return {
+      success: false,
+      error: `Unsupported protocol version: expected ${GOMI_BRIDGE_PROTOCOL_VERSION}, got ${String(rec.protocolVersion)}`,
+    };
+  }
+
+  // 4 – Schema validation
+  const result = GomiBridgeMessageSchema.safeParse(value);
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((i) => {
+        const path = i.path.length ? i.path.join('.') : '<root>';
+        return `${path}: ${i.message}`;
+      })
+      .join('; ');
+    return { success: false, error: `Invalid message schema: ${issues}` };
+  }
+
+  return { success: true, message: result.data };
+}

--- a/tests/gomiMessageValidator.test.ts
+++ b/tests/gomiMessageValidator.test.ts
@@ -1,0 +1,445 @@
+/**
+ * Unit tests for src/vs/workbench/contrib/gomi/common/gomiMessageValidator.ts
+ *
+ * Covers:
+ *   - All valid message types accepted
+ *   - Size limits enforced (DoS protection)
+ *   - Protocol version mismatch rejected
+ *   - Malformed / missing fields rejected
+ *   - Path traversal in patch filePath rejected
+ *   - Unknown message types rejected
+ *   - Non-object / array / null input rejected
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  GOMI_BRIDGE_MAX_MESSAGE_BYTES,
+  GOMI_BRIDGE_PROTOCOL_VERSION,
+  validateGomiBridgeMessage,
+  type GomiBridgeMessage,
+} from '../src/vs/workbench/contrib/gomi/common/gomiMessageValidator';
+
+const proto = { protocolVersion: GOMI_BRIDGE_PROTOCOL_VERSION as const };
+
+// ── helpers ────────────────────────────────────────
+const validRun = (): unknown => ({
+  ...proto,
+  type: 'gomi.run',
+  request: 'Review workspace',
+});
+
+const validStop = (): unknown => ({
+  ...proto,
+  type: 'gomi.stop',
+  reason: 'User cancelled',
+});
+
+const validApplyPatch = (): unknown => ({
+  ...proto,
+  type: 'gomi.applyPatch',
+  patch: {
+    id: 'patch-1',
+    filePath: 'src/index.ts',
+    targetFiles: ['src/index.ts'],
+    summary: 'Fix typo',
+    diff: 'diff --git a/src/index.ts b/src/index.ts\n@@ -1 +1 @@\n-old\n+new',
+    approvalStatus: 'pending',
+    riskLevel: 'low',
+    createdByAgentId: 'ceo',
+  },
+});
+
+const validBridgeError = (): unknown => ({
+  ...proto,
+  type: 'gomi.bridgeError',
+  code: 'invalid_message',
+  message: 'Rejected invalid Gomi bridge message.',
+});
+
+const validPreviewPatchResult = (): unknown => ({
+  ...proto,
+  type: 'gomi.previewPatchResult',
+  patchId: '550e8400-e29b-41d4-a716-446655440000',
+  result: { previewedFiles: ['README.md'] },
+});
+
+const validApplyPatchResult = (): unknown => ({
+  ...proto,
+  type: 'gomi.applyPatchResult',
+  patchId: '550e8400-e29b-41d4-a716-446655440000',
+  result: { appliedFiles: ['README.md'] },
+});
+
+const validPruneMemory = (): unknown => ({
+  ...proto,
+  type: 'gomi.pruneMemory',
+});
+
+const validPruneMemoryResult = (): unknown => ({
+  ...proto,
+  type: 'gomi.pruneMemoryResult',
+  report: { pruned: 42 },
+});
+
+const validEvent = (): unknown => ({
+  ...proto,
+  type: 'gomi.event',
+  event: { type: 'session_started', sessionId: 's1' },
+});
+
+// ────────────────────────────────────────────────────
+describe('validateGomiBridgeMessage', () => {
+  // ── Happy path ──────────────────────────────────
+  it('accepts a valid gomi.run message', () => {
+    const res = validateGomiBridgeMessage(validRun());
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.message.type).toBe('gomi.run');
+      expect(res.message.request).toBe('Review workspace');
+    }
+  });
+
+  it('accepts gomi.run with officeSettings', () => {
+    const msg = {
+      ...proto,
+      type: 'gomi.run',
+      request: 'Run agents',
+      officeSettings: {
+        seats: [
+          {
+            id: 's1',
+            agentId: 'backend',
+            name: 'Backend Agent',
+            role: 'Writes code',
+            seatKind: 'employee',
+            providerId: 'codex-cli',
+            workMode: 'active',
+            canSleep: true,
+            canFire: true,
+          },
+        ],
+        memory: {
+          retrievalMode: 'hybrid-vector',
+          embeddingProvider: 'local-hashing',
+          embeddingExecutionEnabled: false,
+          sharedMemoryEnabled: true,
+          indexWorkspaceContext: true,
+          privacyMode: 'standard',
+          redactSecrets: true,
+          retentionDays: 30,
+          maxProjectMemoryItems: 500,
+          broadcastThreshold: 0.5,
+          requirePatchApproval: true,
+        },
+        execution: {
+          workspaceTrust: 'trusted',
+          liveProviderMode: 'demo-only',
+          allowCliProviders: true,
+          allowHttpProviders: false,
+          requirePatchApprovalForLiveProviders: true,
+          maxConcurrentAgentRuns: 4,
+        },
+      },
+    };
+    const res = validateGomiBridgeMessage(msg);
+    expect(res.success).toBe(true);
+    if (res.success) {
+      expect(res.message.officeSettings?.seats).toHaveLength(1);
+    }
+  });
+
+  it('accepts a valid gomi.stop message', () => {
+    const res = validateGomiBridgeMessage(validStop());
+    expect(res.success).toBe(true);
+  });
+
+  it('accepts gomi.stop without optional reason', () => {
+    const res = validateGomiBridgeMessage({ ...proto, type: 'gomi.stop' });
+    expect(res.success).toBe(true);
+  });
+
+  it('accepts a valid gomi.applyPatch message', () => {
+    const res = validateGomiBridgeMessage(validApplyPatch());
+    expect(res.success).toBe(true);
+  });
+
+  it('accepts a valid gomi.previewPatch message', () => {
+    const res = validateGomiBridgeMessage({
+      ...proto,
+      type: 'gomi.previewPatch',
+      patch: (validApplyPatch() as Record<string, unknown>).patch,
+    });
+    expect(res.success).toBe(true);
+  });
+
+  it('accepts a valid gomi.previewPatchResult message', () => {
+    const res = validateGomiBridgeMessage(validPreviewPatchResult());
+    expect(res.success).toBe(true);
+  });
+
+  it('accepts a valid gomi.applyPatchResult message', () => {
+    const res = validateGomiBridgeMessage(validApplyPatchResult());
+    expect(res.success).toBe(true);
+  });
+
+  it('accepts a valid gomi.pruneMemory message', () => {
+    const res = validateGomiBridgeMessage(validPruneMemory());
+    expect(res.success).toBe(true);
+  });
+
+  it('accepts a valid gomi.pruneMemoryResult message', () => {
+    const res = validateGomiBridgeMessage(validPruneMemoryResult());
+    expect(res.success).toBe(true);
+  });
+
+  it('accepts a valid gomi.event message', () => {
+    const res = validateGomiBridgeMessage(validEvent());
+    expect(res.success).toBe(true);
+  });
+
+  it('accepts a valid gomi.bridgeError message', () => {
+    const res = validateGomiBridgeMessage(validBridgeError());
+    expect(res.success).toBe(true);
+  });
+
+  // ── Rejection: size limits ──────────────────────
+  it('rejects oversized payload (>64 KB)', () => {
+    const huge = {
+      ...proto,
+      type: 'gomi.run',
+      request: 'x'.repeat(GOMI_BRIDGE_MAX_MESSAGE_BYTES),
+    };
+    const res = validateGomiBridgeMessage(huge);
+    expect(res.success).toBe(false);
+    if (!res.success) {
+      expect(res.error).toContain('too large');
+    }
+  });
+
+  // ── Rejection: protocol version ─────────────────
+  it('rejects wrong protocol version', () => {
+    const res = validateGomiBridgeMessage({
+      protocolVersion: 2,
+      type: 'gomi.stop',
+    });
+    expect(res.success).toBe(false);
+    if (!res.success) {
+      expect(res.error).toContain('Unsupported protocol version');
+    }
+  });
+
+  it('rejects missing protocol version', () => {
+    const res = validateGomiBridgeMessage({ type: 'gomi.stop' });
+    expect(res.success).toBe(false);
+    if (!res.success) {
+      expect(res.error).toContain('protocol version');
+    }
+  });
+
+  // ── Rejection: unknown / malicious types ────────
+  it('rejects unknown message type', () => {
+    const res = validateGomiBridgeMessage({
+      ...proto,
+      type: 'gomi.danger',
+    });
+    expect(res.success).toBe(false);
+    if (!res.success) {
+      expect(res.error).toContain('Invalid message schema');
+    }
+  });
+
+  it('rejects non-Gomi string type', () => {
+    const res = validateGomiBridgeMessage({
+      ...proto,
+      type: 'workspace.event',
+    });
+    expect(res.success).toBe(false);
+  });
+
+  // ── Rejection: non-object input ─────────────────
+  it('rejects null input', () => {
+    const res = validateGomiBridgeMessage(null);
+    expect(res.success).toBe(false);
+  });
+
+  it('rejects array input', () => {
+    const res = validateGomiBridgeMessage([{ ...proto, type: 'gomi.stop' }]);
+    expect(res.success).toBe(false);
+  });
+
+  it('rejects string input', () => {
+    const res = validateGomiBridgeMessage('not a message');
+    expect(res.success).toBe(false);
+  });
+
+  it('rejects number input', () => {
+    const res = validateGomiBridgeMessage(42);
+    expect(res.success).toBe(false);
+  });
+
+  // ── Rejection: malformed fields ─────────────────
+  it('rejects gomi.run with missing request', () => {
+    const res = validateGomiBridgeMessage({ ...proto, type: 'gomi.run' });
+    expect(res.success).toBe(false);
+    if (!res.success) {
+      expect(res.error).toContain('schema');
+    }
+  });
+
+  it('rejects gomi.run with oversized request text', () => {
+    const res = validateGomiBridgeMessage({
+      ...proto,
+      type: 'gomi.run',
+      request: 'x'.repeat(20_000),
+    });
+    expect(res.success).toBe(false);
+  });
+
+  it('rejects patch with path traversal in filePath', () => {
+    const msg = validApplyPatch() as Record<string, unknown>;
+    (msg.patch as Record<string, unknown>).filePath = '../secret.txt';
+    const res = validateGomiBridgeMessage(msg);
+    expect(res.success).toBe(false);
+    if (!res.success) {
+      expect(res.error).toContain('relative');
+    }
+  });
+
+  it('rejects patch with path traversal in targetFiles', () => {
+    const msg = validApplyPatch() as Record<string, unknown>;
+    (msg.patch as Record<string, unknown>).targetFiles = ['../escape.txt'];
+    const res = validateGomiBridgeMessage(msg);
+    expect(res.success).toBe(false);
+  });
+
+  it('rejects patch with absolute path', () => {
+    const msg = validApplyPatch() as Record<string, unknown>;
+    (msg.patch as Record<string, unknown>).filePath = '/etc/passwd';
+    const res = validateGomiBridgeMessage(msg);
+    expect(res.success).toBe(false);
+  });
+
+  it('rejects officeSettings with malformed seats', () => {
+    const msg = {
+      ...proto,
+      type: 'gomi.run',
+      request: 'Run agents',
+      officeSettings: { seats: 'not-an-array', memory: {}, execution: {} },
+    };
+    const res = validateGomiBridgeMessage(msg);
+    expect(res.success).toBe(false);
+  });
+
+  it('rejects seat with unknown agentId', () => {
+    const msg = {
+      ...proto,
+      type: 'gomi.run',
+      request: 'Run',
+      officeSettings: {
+        seats: [
+          {
+            id: 's1',
+            agentId: 'hacker',
+            name: 'Bad',
+            role: 'x',
+            seatKind: 'employee',
+            providerId: 'demo-runtime',
+            workMode: 'active',
+            canSleep: false,
+            canFire: false,
+          },
+        ],
+        memory: {
+          retrievalMode: 'hybrid-vector',
+          embeddingProvider: 'local-hashing',
+          embeddingExecutionEnabled: false,
+          sharedMemoryEnabled: true,
+          indexWorkspaceContext: true,
+          privacyMode: 'standard',
+          redactSecrets: true,
+          retentionDays: 30,
+          maxProjectMemoryItems: 500,
+          broadcastThreshold: 0,
+          requirePatchApproval: true,
+        },
+        execution: {
+          workspaceTrust: 'trusted',
+          liveProviderMode: 'demo-only',
+          allowCliProviders: true,
+          allowHttpProviders: false,
+          requirePatchApprovalForLiveProviders: true,
+          maxConcurrentAgentRuns: 4,
+        },
+      },
+    };
+    const res = validateGomiBridgeMessage(msg);
+    expect(res.success).toBe(false);
+  });
+
+  it('rejects oversized base64 patch diff', () => {
+    const msg = validApplyPatch() as Record<string, unknown>;
+    (msg.patch as Record<string, unknown>).diff = 'x'.repeat(70_000);
+    const res = validateGomiBridgeMessage(msg);
+    expect(res.success).toBe(false);
+  });
+
+  it('rejects empty string fields where min(1) is enforced', () => {
+    const msg = validApplyPatch() as Record<string, unknown>;
+    (msg.patch as Record<string, unknown>).summary = '';
+    const res = validateGomiBridgeMessage(msg);
+    expect(res.success).toBe(false);
+  });
+
+  // ── Trust boundary: error message never leaks raw values ──
+  it('does not leak raw payload values in error message', () => {
+    const malicious = {
+      ...proto,
+      type: 'gomi.run',
+      request: '',
+      __secret: 'should-not-leak',
+    };
+    const res = validateGomiBridgeMessage(malicious);
+    expect(res.success).toBe(false);
+    if (!res.success) {
+      // The error MAY name unrecognized keys (for debugging) but MUST NOT
+      // expose their values — the string 'should-not-leak' must never
+      // appear in the error.
+      expect(res.error).not.toContain('should-not-leak');
+    }
+  });
+
+  // ── Regression: unknown keys rejected ───────────
+  it('rejects messages with extra unknown keys', () => {
+    const res = validateGomiBridgeMessage({
+      ...validRun(),
+      injected: true,
+    });
+    expect(res.success).toBe(false);
+  });
+});
+
+// ────────────────────────────────────────────────────
+describe('GomiBridgeMessageSchema type coverage', () => {
+  it('validates every defined message type at least once', () => {
+    const cases: Array<{ label: string; input: unknown }> = [
+      { label: 'gomi.run', input: validRun() },
+      { label: 'gomi.stop', input: validStop() },
+      { label: 'gomi.pruneMemory', input: validPruneMemory() },
+      { label: 'gomi.pruneMemoryResult', input: validPruneMemoryResult() },
+      { label: 'gomi.applyPatch', input: validApplyPatch() },
+      { label: 'gomi.previewPatch', input: { ...proto, type: 'gomi.previewPatch', patch: (validApplyPatch() as Record<string, unknown>).patch } },
+      { label: 'gomi.previewPatchResult', input: validPreviewPatchResult() },
+      { label: 'gomi.applyPatchResult', input: validApplyPatchResult() },
+      { label: 'gomi.event', input: validEvent() },
+      { label: 'gomi.bridgeError', input: validBridgeError() },
+    ];
+
+    for (const { label, input } of cases) {
+      const res = validateGomiBridgeMessage(input);
+      expect(res.success).toBe(true);
+      if (res.success) {
+        expect(res.message.type).toBe(label);
+      }
+    }
+  });
+});

--- a/tests/gomiWebviewHostBridge.test.ts
+++ b/tests/gomiWebviewHostBridge.test.ts
@@ -92,33 +92,23 @@ describe('Gomi webview host bridge', () => {
       }
     });
 
+    // No valid messages should reach listeners
     expect(received).toEqual([]);
-    expect(webview.outbox).toEqual([
-      {
+
+    // Four bridge error responses were sent, each with a specific reason
+    expect(webview.outbox).toHaveLength(4);
+    for (const msg of webview.outbox) {
+      expect(msg).toMatchObject({
         protocolVersion: 1,
         type: 'gomi.bridgeError',
         code: 'invalid_message',
-        message: 'Rejected invalid Gomi bridge message.'
-      },
-      {
-        protocolVersion: 1,
-        type: 'gomi.bridgeError',
-        code: 'invalid_message',
-        message: 'Rejected invalid Gomi bridge message.'
-      },
-      {
-        protocolVersion: 1,
-        type: 'gomi.bridgeError',
-        code: 'invalid_message',
-        message: 'Rejected invalid Gomi bridge message.'
-      },
-      {
-        protocolVersion: 1,
-        type: 'gomi.bridgeError',
-        code: 'invalid_message',
-        message: 'Rejected invalid Gomi bridge message.'
-      }
-    ]);
+      });
+      expect(typeof msg.message).toBe('string');
+      expect(msg.message.length).toBeGreaterThan(0);
+      expect(msg.message).toContain('Rejected invalid Gomi bridge message');
+    }
+
+    // Error messages must never expose raw payload data
     expect(JSON.stringify(webview.outbox)).not.toContain('../secret');
   });
 });


### PR DESCRIPTION
…#22, 100 MRG)

- Add gomiMessageValidator.ts with Zod schemas for all 10 bridge message types
- Strict validation: protocol version, size limits, enum constraints, path safety
- Integrate validator into GomiWebviewHostBridge for detailed error messages
- 33 new unit tests covering accept/reject/trust-boundary/size-limit cases
- All 193 tests pass (33 new + 160 existing)
- Protocol note and schema documentation in code comments
- Dependency: zod (already npm-compatible, no breaking changes)

Closes #22

## Summary

This pull request introduces the Gomi IDE foundation: a Code - OSS fork direction with Gomi branding, a multi-agent office workflow, and a visual Gomi Office experience for planning and reviewing software work.

## Highlights

- Adds Gomi product branding metadata.
- Adds the `src/vs/workbench/contrib/gomi` module structure for future Code - OSS integration.
- Adds a React workbench demo for the Gomi Office panel.
- Adds a Phaser 2D office scene with animated game-style agents, a memory board, and chat bubbles.
- Adds a CEO Agent runtime simulation with task planning, event streaming, final reports, and patch proposals.
- Adds tests for the message bus, planner, and runtime flow.

## Screenshot

![Gomi Office IDE interface](docs/images/gomi-office-cute-office.png)

## Verification

- [ ] `npm run typecheck`
- [ ] `npm test`
- [ ] `npm run build`
- [ ] Visual QA confirms the Phaser office canvas renders agents, memory board, and chat bubbles.

## Notes

This is not a VS Code extension release. It is a scaffold for a standalone Gomi IDE direction based on a Code - OSS fork.
