### PR TITLE
docs: add CONTRIBUTING.md, SECURITY.md, CODE_OF_CONDUCT.md (issue #46, 25 MRG)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,45 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes
+- Focusing on what is best for the overall community
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Contributing to Gomi IDE
+
+Thanks for contributing! Gomi IDE is a MergeOS-funded project — many issues carry **MRG token bounties**.
+
+## Bounty workflow
+
+1. **Star** [mergeos-bounties/mergeos](https://github.com/mergeos-bounties/mergeos)
+2. **Claim** on both:
+   - [mergeos#1 — Claim MRG Tokens](https://github.com/mergeos-bounties/mergeos/issues/1)
+   - [mergeos#244 — Gomi IDE job tracker](https://github.com/mergeos-bounties/mergeos/issues/244)
+3. **Fork** this repo, create a feature branch, implement the fix
+4. **Open a PR** targeting `master`, linking the issue number and `mergeos#244`
+5. **Pass the quality gate** (see below)
+6. After merge, MRG is credited to `github:<PR author>` on the MergeOS admin ledger
+
+## Local verify script
+
+```bash
+npm ci && npm run typecheck && npm test
+```
+
+One command to verify everything is green before pushing.
+
+## Quality gate
+
+CI runs these checks on every PR. Make sure they pass locally:
+
+```bash
+npm run typecheck   # TypeScript compilation
+npm test            # Vitest suite (193+ tests)
+```
+
+## Code style
+
+- TypeScript strict mode
+- Prefer explicit types over `any`
+- New message types MUST be registered in the bridge validator (see `src/vs/workbench/contrib/gomi/common/gomiMessageValidator.ts`)
+- Keep public APIs backward-compatible unless the issue explicitly allows breaking changes
+
+## Pull request guidelines
+
+- One focused change per PR
+- Link the issue with `Closes #NN`
+- Include evidence: test output, screenshots (for UI changes), or logs
+- No secrets, keys, or credentials in commits or PR descriptions
+
+## Security
+
+See [SECURITY.md](SECURITY.md) for reporting vulnerabilities. Never commit secrets — use environment variables or Electron `safeStorage`.
+
+## Code of Conduct
+
+See [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,50 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Do not open a public issue.** Email the maintainers directly.
+
+## Supported versions
+
+| Version | Supported |
+|---------|-----------|
+| 0.1.x (master) | Yes |
+
+## Security model
+
+Gomi IDE runs on your local machine. Key trust boundaries:
+
+### Provider API keys
+Store provider keys via Electron `safeStorage` (or OS keychain) when packaged. Never commit keys or write them into plain JSON. For the web prototype, use environment variables with a memory-only fallback.
+
+### Workspace access
+- Agents run with the user's filesystem permissions
+- Patch approval is required before any file modification
+- The patch applier blocks path escape outside the workspace root
+- Workspace trust state gates live provider execution
+
+### Webview bridge
+All messages crossing the webview/host boundary are validated:
+- Protocol version enforcement
+- Payload size limits (64 KB)
+- Strict schema validation per message type
+- Unknown or malformed messages are rejected with a safe error event
+
+### Memory & privacy
+- `.env` and secret files are excluded from indexing
+- Memory retention is configurable (days / item cap)
+- Strict privacy mode redacts sensitive patterns
+
+## Disclosure timeline
+
+- Acknowledgment within 48 hours
+- Fix within 7 days for critical issues
+- Public disclosure after fix is merged and released
+
+## Out of scope
+
+- Social engineering
+- Physical access attacks
+- Denial of service via resource exhaustion (file count, payload size)
+
+Thank you for helping keep Gomi IDE secure.


### PR DESCRIPTION
## Summary
Adds project governance documentation required by issue #46.

### Changes
- **New:** CONTRIBUTING.md — MergeOS bounty workflow, verify script, quality gate
- **New:** SECURITY.md — Vulnerability reporting, threat model, trust boundaries
- **New:** CODE_OF_CONDUCT.md — Contributor Covenant v2.0

### Acceptance Criteria
- [x] File present on default branch via PR
- [x] Links valid (mergeos#1, mergeos#244, SECURITY.md)
- [x] No secrets

Closes #46