### PR TITLE
feat: add Zod-based agent result schema validation (issue #44, 100 MRG)

### DIFF
--- a/src/vs/workbench/contrib/gomi/common/gomiAgentResultSchema.ts
+++ b/src/vs/workbench/contrib/gomi/common/gomiAgentResultSchema.ts
@@ -1,0 +1,142 @@
+/**
+ * GomiAgentResultSchema — Zod-based schema for agent result validation.
+ * ----------------------------------------------------------------
+ * SCHEMA DOCUMENTATION (version 1):
+ *
+ * Every CLI/HTTP agent result MAY include a `schemaVersion` field.
+ * When present and equal to 1, the result object is validated against
+ * the schema below. Unknown future versions are rejected at the parser
+ * level so the caller can fall back to plain-text interpretation.
+ *
+ * Fields (all optional for backward compatibility):
+ *   schemaVersion: 1                    — Schema discriminator
+ *   agentId: GomiAgentId                — Which agent produced this
+ *   taskId: string                      — Associated task identifier
+ *   summary: string (max 8 000 chars)   — Human-readable summary
+ *   findings: string[] (max 50 items)   — Concrete observations
+ *   recommendations: string[] (max 20)  — Actionable next steps
+ *   proposedFiles: string[] (max 100)   — Files to create/modify
+ *   confidence: number (0.0 – 1.0)      — Agent's self-assessed confidence
+ *   usageEstimate: { inputTokens, outputTokens, ... }
+ *
+ * Size limits prevent DoS via oversized fields.
+ * All string fields enforce min(1) — empty strings are rejected.
+ * Unknown extra keys are rejected (strict mode).
+ */
+
+import { z } from 'zod';
+import type { GomiAgentId } from '../common/gomiTypes';
+
+// ────────────────────────────────────────────────
+//  Constants
+// ────────────────────────────────────────────────
+export const GOMI_AGENT_RESULT_SCHEMA_VERSION = 1;
+const MAX_SUMMARY_LENGTH = 8_000;
+const MAX_FINDING_LENGTH = 4_000;
+const MAX_RECOMMENDATION_LENGTH = 2_000;
+const MAX_FINDINGS = 50;
+const MAX_RECOMMENDATIONS = 20;
+const MAX_PROPOSED_FILES = 100;
+const MAX_FILE_PATH = 500;
+
+const agentIdValues: readonly GomiAgentId[] = [
+  'ceo', 'system-analyst', 'backend', 'frontend',
+  'designer', 'database', 'qa', 'devops',
+];
+
+const agentIdSchema = z.enum(agentIdValues);
+
+// ────────────────────────────────────────────────
+//  Sub-schemas
+// ────────────────────────────────────────────────
+const usageEstimateSchema = z.object({
+  providerId: agentIdSchema.optional(),
+  model: z.string().min(1).max(200).optional(),
+  inputTokens: z.number().int().min(0),
+  outputTokens: z.number().int().min(0),
+  totalTokens: z.number().int().min(0),
+  estimatedCostUsd: z.number().min(0),
+  hasEstimatedTokens: z.boolean(),
+}).strict();
+
+// ────────────────────────────────────────────────
+//  Agent Result Schema v1
+// ────────────────────────────────────────────────
+export const GomiAgentResultSchema = z.object({
+  schemaVersion: z.literal(GOMI_AGENT_RESULT_SCHEMA_VERSION).optional(),
+  agentId: agentIdSchema.optional(),
+  taskId: z.string().min(1).max(200).optional(),
+  summary: z.string().min(1).max(MAX_SUMMARY_LENGTH).optional(),
+  findings: z.array(z.string().min(1).max(MAX_FINDING_LENGTH)).max(MAX_FINDINGS).optional(),
+  recommendations: z.array(z.string().min(1).max(MAX_RECOMMENDATION_LENGTH)).max(MAX_RECOMMENDATIONS).optional(),
+  proposedFiles: z.array(z.string().min(1).max(MAX_FILE_PATH)).max(MAX_PROPOSED_FILES).optional(),
+  confidence: z.number().min(0).max(1).optional(),
+  usageEstimate: usageEstimateSchema.optional(),
+}).strict();
+
+export type ValidatedAgentResult = z.infer<typeof GomiAgentResultSchema>;
+
+// ────────────────────────────────────────────────
+//  Validation helpers
+// ────────────────────────────────────────────────
+
+export interface AgentResultValidationResult {
+  value?: ValidatedAgentResult;
+  errors: string[];
+  warnings: string[];
+}
+
+/**
+ * Validate a parsed JSON object against the agent result schema.
+ *
+ * @param value The parsed JSON value (from JSON.parse or equivalent)
+ * @returns Structured result with validated value, errors, and warnings
+ *
+ * Never throws. All rejection reasons are returned as structured errors.
+ */
+export function validateAgentResult(value: unknown): AgentResultValidationResult {
+  const result: AgentResultValidationResult = { errors: [], warnings: [] };
+
+  // Guard: must be a plain object
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    result.errors.push('Agent result must be a JSON object, got ' + (value === null ? 'null' : typeof value));
+    return result;
+  }
+
+  const rec = value as Record<string, unknown>;
+
+  // If no schemaVersion, accept as-is (free-text fallback compatible)
+  if (rec.schemaVersion === undefined) {
+    // Basic sanity: warn on suspicious fields
+    if (typeof rec.summary === 'string' && rec.summary.length > MAX_SUMMARY_LENGTH) {
+      result.warnings.push(`summary exceeds ${MAX_SUMMARY_LENGTH} chars, will be truncated`);
+    }
+    result.value = value as ValidatedAgentResult;
+    return result;
+  }
+
+  // Unknown schema version → reject (caller falls back to free text)
+  if (rec.schemaVersion !== GOMI_AGENT_RESULT_SCHEMA_VERSION) {
+    result.errors.push(
+      `Unsupported agent result schemaVersion ${String(rec.schemaVersion)}. ` +
+      `Expected ${GOMI_AGENT_RESULT_SCHEMA_VERSION}.`
+    );
+    return result;
+  }
+
+  // Schema validation
+  const parsed = GomiAgentResultSchema.safeParse(value);
+  if (!parsed.success) {
+    const issues = parsed.error.issues
+      .map((i) => {
+        const path = i.path.length ? i.path.join('.') : '<root>';
+        return `${path}: ${i.message}`;
+      })
+      .join('; ');
+    result.errors.push(`Agent result schema validation failed: ${issues}`);
+    return result;
+  }
+
+  result.value = parsed.data;
+  return result;
+}

--- a/src/vs/workbench/contrib/gomi/node/agentOutputParsing.ts
+++ b/src/vs/workbench/contrib/gomi/node/agentOutputParsing.ts
@@ -2,6 +2,7 @@ import type {
   GomiAgentResult,
   GomiAgentResultSchemaVersion
 } from '../common/gomiTypes';
+import { validateAgentResult, type AgentResultValidationResult } from '../common/gomiAgentResultSchema';
 
 export const GOMI_AGENT_RESULT_SCHEMA_VERSION = 1 satisfies GomiAgentResultSchemaVersion;
 
@@ -32,7 +33,7 @@ export function parseAgentResultJsonWithDiagnostics(text: string): GomiAgentResu
     const parsed = tryParseObject(candidate);
 
     if (parsed.value) {
-      return normalizeAgentResultObject(parsed.value);
+      return normalizeWithSchema(parsed.value);
     }
 
     diagnostics.push(parsed.error ?? 'Agent result JSON candidate could not be parsed.');
@@ -45,7 +46,7 @@ export function parseAgentResultJsonWithDiagnostics(text: string): GomiAgentResu
     const parsed = tryParseObject(completedCandidate);
 
     if (parsed.value) {
-      const normalized = normalizeAgentResultObject(parsed.value);
+      const normalized = normalizeWithSchema(parsed.value);
       return {
         value: normalized.value,
         diagnostics: [
@@ -62,6 +63,25 @@ export function parseAgentResultJsonWithDiagnostics(text: string): GomiAgentResu
     diagnostics: diagnostics.length > 0
       ? diagnostics
       : ['No agent result JSON object was found.']
+  };
+}
+
+/**
+ * Run the parsed object through the Zod schema validator.
+ * Merges schema validation errors/warnings into the diagnostics stream.
+ */
+function normalizeWithSchema(value: AgentResultRecord): GomiAgentResultParseResult {
+  const validation = validateAgentResult(value);
+
+  // Schema validation errors are fatal — no value returned
+  if (validation.errors.length > 0) {
+    return { diagnostics: validation.errors };
+  }
+
+  // Return validated value with any warnings as diagnostics
+  return {
+    value: (validation.value ?? value) as Partial<GomiAgentResult>,
+    diagnostics: validation.warnings
   };
 }
 

--- a/tests/agentOutputParsing.test.ts
+++ b/tests/agentOutputParsing.test.ts
@@ -36,7 +36,7 @@ describe('agent output parsing', () => {
     }));
 
     expect(result.value).toBeUndefined();
-    expect(result.diagnostics).toContain('Unsupported agent result schemaVersion 99.');
+    expect(result.diagnostics[0]).toContain('Unsupported agent result schemaVersion');
   });
 
   it('recovers a truncated versioned JSON object when required closers are missing', () => {

--- a/tests/gomiAgentResultSchema.test.ts
+++ b/tests/gomiAgentResultSchema.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Unit tests for agent result schema validation (issue #44).
+ * Covers: Zod schema validation, size limits, truncated recovery,
+ * backward compatibility, garbage input safety.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { validateAgentResult } from '../src/vs/workbench/contrib/gomi/common/gomiAgentResultSchema';
+import { parseAgentResultJson, parseAgentResultJsonWithDiagnostics } from '../src/vs/workbench/contrib/gomi/node/agentOutputParsing';
+
+const toJson = (obj: unknown) => JSON.stringify(obj);
+
+// ────────────────────────────────────────────────
+describe('GomiAgentResultSchema', () => {
+  describe('validateAgentResult', () => {
+    it('accepts a valid v1 result', () => {
+      const r = validateAgentResult({
+        schemaVersion: 1,
+        agentId: 'backend',
+        taskId: 'task-1',
+        summary: 'Login path reviewed.',
+        findings: ['Controller requires patch approval.'],
+        recommendations: ['Open diff preview.'],
+        proposedFiles: ['src/api/login.ts'],
+        confidence: 0.86,
+      });
+      expect(r.errors).toEqual([]);
+      expect(r.value?.summary).toBe('Login path reviewed.');
+      expect(r.value?.confidence).toBe(0.86);
+    });
+
+    it('accepts minimal result (no schemaVersion, backward compat)', () => {
+      const r = validateAgentResult({
+        summary: 'Just a summary.',
+        findings: ['Finding 1'],
+      });
+      expect(r.errors).toEqual([]);
+      expect(r.value?.summary).toBe('Just a summary.');
+    });
+
+    it('rejects unsupported schemaVersion', () => {
+      const r = validateAgentResult({
+        schemaVersion: 99,
+        summary: 'Future version.',
+      });
+      expect(r.errors).toHaveLength(1);
+      expect(r.errors[0]).toContain('Unsupported agent result schemaVersion');
+    });
+
+    it('rejects non-object input', () => {
+      expect(validateAgentResult(null).errors).toHaveLength(1);
+      expect(validateAgentResult([]).errors).toHaveLength(1);
+      expect(validateAgentResult('string').errors).toHaveLength(1);
+      expect(validateAgentResult(42).errors).toHaveLength(1);
+    });
+
+    it('rejects oversized summary (>8 000 chars)', () => {
+      const r = validateAgentResult({
+        schemaVersion: 1,
+        summary: 'x'.repeat(9_000),
+      });
+      expect(r.errors).toHaveLength(1);
+    });
+
+    it('rejects confidence outside 0-1 range', () => {
+      const r = validateAgentResult({
+        schemaVersion: 1,
+        confidence: 1.5,
+      });
+      expect(r.errors).toHaveLength(1);
+    });
+
+    it('rejects empty string fields', () => {
+      const r = validateAgentResult({
+        schemaVersion: 1,
+        summary: '',
+        agentId: 'backend',
+      });
+      expect(r.errors).toHaveLength(1);
+    });
+
+    it('rejects unknown agentId', () => {
+      const r = validateAgentResult({
+        schemaVersion: 1,
+        agentId: 'hacker',
+      });
+      expect(r.errors).toHaveLength(1);
+    });
+
+    it('rejects extra unknown keys', () => {
+      const r = validateAgentResult({
+        schemaVersion: 1,
+        __malicious: true,
+      });
+      expect(r.errors).toHaveLength(1);
+    });
+
+    it('rejects oversized arrays', () => {
+      const r = validateAgentResult({
+        schemaVersion: 1,
+        findings: Array.from({ length: 100 }, (_, i) => `finding-${i}`),
+      });
+      expect(r.errors).toHaveLength(1);
+    });
+
+    it('warns on oversized summary without schemaVersion', () => {
+      const r = validateAgentResult({
+        summary: 'x'.repeat(9_000),
+      });
+      expect(r.errors).toEqual([]);
+      expect(r.warnings.length).toBeGreaterThan(0);
+      expect(r.warnings[0]).toContain('truncated');
+    });
+
+    it('accepts result with usageEstimate', () => {
+      const r = validateAgentResult({
+        schemaVersion: 1,
+        summary: 'Done.',
+        usageEstimate: {
+          inputTokens: 100,
+          outputTokens: 50,
+          totalTokens: 150,
+          estimatedCostUsd: 0.001,
+          hasEstimatedTokens: true,
+        },
+      });
+      expect(r.errors).toEqual([]);
+      expect(r.value?.usageEstimate?.totalTokens).toBe(150);
+    });
+  });
+});
+
+// ────────────────────────────────────────────────
+describe('agent output parsing (extended)', () => {
+  describe('backward compatibility', () => {
+    it('accepts the versioned agent result schema', () => {
+      const parsed = parseAgentResultJson(toJson({
+        schemaVersion: 1,
+        summary: 'Backend agent reviewed the login path.',
+        findings: ['The controller still requires patch approval.'],
+        recommendations: ['Open the native diff preview before applying changes.'],
+        proposedFiles: ['src/api/login.ts'],
+        confidence: 0.86,
+      }));
+      expect(parsed).toMatchObject({
+        schemaVersion: 1,
+        summary: 'Backend agent reviewed the login path.',
+        confidence: 0.86,
+      });
+    });
+
+    it('accepts result without schemaVersion (free-text fallback)', () => {
+      const parsed = parseAgentResultJson(toJson({
+        summary: 'Plain result without version.',
+        findings: ['Works.'],
+      }));
+      expect(parsed).toMatchObject({
+        summary: 'Plain result without version.',
+      });
+    });
+
+    it('rejects unsupported schema versions', () => {
+      const result = parseAgentResultJsonWithDiagnostics(toJson({
+        schemaVersion: 99,
+        summary: 'Future schema payload.',
+      }));
+      expect(result.value).toBeUndefined();
+      expect(result.diagnostics[0]).toContain('Unsupported agent result schemaVersion 99');
+    });
+
+    it('recovers truncated JSON objects', () => {
+      const parsed = parseAgentResultJson([
+        'Model response:',
+        '```json',
+        '{"schemaVersion":1,"summary":"Partial run","findings":["Recovered finding"],"recommendations":["Review recovered fields"],"proposedFiles":["src/api/login.ts"],"confidence":0.73',
+      ].join('\n'));
+      expect(parsed).toMatchObject({
+        schemaVersion: 1,
+        summary: 'Partial run',
+        confidence: 0.73,
+      });
+    });
+
+    it('returns undefined for plain text without JSON', () => {
+      expect(parseAgentResultJson('plain model text without JSON')).toBeUndefined();
+    });
+
+    it('returns undefined for garbage truncated JSON', () => {
+      expect(parseAgentResultJson('{"schemaVersion":1,"summary":')).toBeUndefined();
+    });
+  });
+
+  describe('robustness', () => {
+    it('handles empty input gracefully', () => {
+      const result = parseAgentResultJsonWithDiagnostics('');
+      expect(result.value).toBeUndefined();
+      expect(result.diagnostics[0]).toContain('empty');
+    });
+
+    it('handles whitespace-only input', () => {
+      const result = parseAgentResultJsonWithDiagnostics('   \n  ');
+      expect(result.value).toBeUndefined();
+    });
+
+    it('handles nested JSON objects in text', () => {
+      const text = 'Here is the result {"summary":"First"} and another {"summary":"Second"}';
+      const parsed = parseAgentResultJson(text);
+      // Should pick the last valid object
+      expect(parsed?.summary).toBe('Second');
+    });
+
+    it('does not crash on malformed Unicode', () => {
+      const result = parseAgentResultJsonWithDiagnostics('{"summary":"\uD800"}');
+      // May fail to parse, but must not throw
+      expect(result).toBeDefined();
+    });
+
+    it('rejects result with invalid agentId via schema validation', () => {
+      const result = parseAgentResultJsonWithDiagnostics(toJson({
+        schemaVersion: 1,
+        agentId: 'attacker',
+        summary: 'Test',
+      }));
+      expect(result.value).toBeUndefined();
+      expect(result.diagnostics.length).toBeGreaterThan(0);
+    });
+
+    it('rejects result with confidence out of range', () => {
+      const result = parseAgentResultJsonWithDiagnostics(toJson({
+        schemaVersion: 1,
+        confidence: 2.0,
+        summary: 'Bad confidence',
+      }));
+      expect(result.value).toBeUndefined();
+      expect(result.diagnostics[0]).toContain('schema validation failed');
+    });
+
+    it('truncated recovery still validates via schema', () => {
+      const truncated = '{"schemaVersion":1,"summary":"Good","findings":["f1","f2"],"confidence":0.5';
+      const parsed = parseAgentResultJson(truncated);
+      expect(parsed).toMatchObject({
+        schemaVersion: 1,
+        summary: 'Good',
+        confidence: 0.5,
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds Zod-based schema validation for agent results, hardening the parser with structured validation, size limits, and clearer errors.

### Changes
- **New:** gomiAgentResultSchema.ts — Zod schema (v1), validateAgentResult(), schema docs
- **Updated:** agentOutputParsing.ts — Integrated Zod validation via normalizeWithSchema()
- **New:** gomiAgentResultSchema.test.ts — 25 tests
- **Updated:** agentOutputParsing.test.ts — Adapted for new error format

### Acceptance Criteria
- [x] Schema documented (JSDoc + inline comments in gomiAgentResultSchema.ts)
- [x] Parser tests expanded (29 tests total: schema, size limits, truncated JSON, garbage input)
- [x] Free-text fallback still works (results without schemaVersion pass through)
- [x] No crash on garbage input (malformed Unicode, truncated, empty input)

### Verification
- npm test: 218 tests pass
- Backward compatible: no schemaVersion = accepted

Closes #44