### PR TITLE
feat: add Zod schema validator for gomi-code-oss.integration.json (issue #26, 100 MRG)

### DIFF
--- a/src/vs/workbench/contrib/gomi/common/gomiCodeOssIntegrationSchema.ts
+++ b/src/vs/workbench/contrib/gomi/common/gomiCodeOssIntegrationSchema.ts
@@ -1,0 +1,107 @@
+/**
+ * GomiCodeOssIntegrationSchema — Zod validator for build/gomi-code-oss.integration.json
+ * -------------------------------------------------------------------------------
+ * SCHEMA DOCUMENTATION:
+ *
+ * The integration manifest defines how Gomi's source files, branding assets,
+ * and templates are overlaid onto a Code - OSS fork. This validator ensures
+ * the manifest is structurally valid before CI or release tooling consumes it.
+ *
+ * Required sections:
+ *   productJson   — Product metadata merge instructions (source, target, mode)
+ *   moduleCopies  — Gomi workbench module source → target copy pairs
+ *   webviewAssetCopies — Office webview bundle copy paths
+ *
+ * To extend the manifest: add new keys to the Zod schema below, then add
+ * corresponding test fixtures in tests/gomiCodeOssIntegrationSchema.test.ts.
+ */
+
+import { z } from 'zod';
+import { readFileSync } from 'node:fs';
+
+// ────────────────────────────────────────────────
+//  Schemas
+// ────────────────────────────────────────────────
+
+const productJsonSchema = z.object({
+  source: z.string().min(1),
+  target: z.string().min(1),
+  mode: z.enum(['merge', 'replace']),
+  removeKeys: z.array(z.string()).optional(),
+}).strict();
+
+const copyPairSchema = z.object({
+  source: z.string().min(1),
+  target: z.string().min(1),
+}).strict();
+
+export const GomiCodeOssIntegrationSchema = z.object({
+  schemaVersion: z.literal(1),
+  productName: z.string().min(1),
+  description: z.string().min(1).optional(),
+  productJson: productJsonSchema,
+  moduleCopies: z.array(copyPairSchema).min(1),
+  templateCopies: z.array(copyPairSchema).optional(),
+  webviewAssetCopies: z.array(copyPairSchema).min(1),
+  resourceCopies: z.array(copyPairSchema).optional(),
+  brandingAssets: z.record(z.string()).optional(),
+  contributionTemplate: z.object({
+    workbenchContribution: z.string().min(1),
+  }).strict().optional(),
+}).strict();
+
+export type GomiCodeOssIntegration = z.infer<typeof GomiCodeOssIntegrationSchema>;
+
+// ────────────────────────────────────────────────
+//  Validation result
+// ────────────────────────────────────────────────
+
+export interface IntegrationValidationResult {
+  valid: boolean;
+  errors: string[];
+  warnings: string[];
+}
+
+// ────────────────────────────────────────────────
+//  Public API
+// ────────────────────────────────────────────────
+
+/**
+ * Validate a parsed integration manifest object.
+ * Never throws — all errors returned as structured result.
+ */
+export function validateIntegrationManifest(
+  data: unknown
+): IntegrationValidationResult {
+  const result = parseResult(GomiCodeOssIntegrationSchema.safeParse(data));
+  return { valid: result.errors.length === 0, errors: result.errors, warnings: [] };
+}
+
+/**
+ * Validate an integration manifest from a JSON file path.
+ */
+export function validateIntegrationManifestFile(
+  filePath: string
+): IntegrationValidationResult {
+  try {
+    const raw = readFileSync(filePath, { encoding: 'utf8' });
+    const data = JSON.parse(raw);
+    return validateIntegrationManifest(data);
+  } catch (err) {
+    return {
+      valid: false,
+      errors: [(err as Error).message],
+      warnings: [],
+    };
+  }
+}
+
+function parseResult(
+  result: ReturnType<typeof GomiCodeOssIntegrationSchema.safeParse>
+): { errors: string[] } {
+  if (result.success) return { errors: [] };
+  const errors = result.error.issues.map(
+    (i) => `${i.path.join('.') || '<root>'}: ${i.message}`
+  );
+  return { errors };
+}

--- a/tests/gomiCodeOssIntegrationSchema.test.ts
+++ b/tests/gomiCodeOssIntegrationSchema.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Tests for gomiCodeOssIntegrationSchema validator (issue #26).
+ */
+
+import { describe, expect, it } from 'vitest';
+import { validateIntegrationManifest } from '../src/vs/workbench/contrib/gomi/common/gomiCodeOssIntegrationSchema';
+
+const validManifest = () => ({
+  schemaVersion: 1,
+  productName: 'Gomi IDE',
+  description: 'Test manifest.',
+  productJson: {
+    source: 'product.json',
+    target: 'product.json',
+    mode: 'merge',
+  },
+  moduleCopies: [
+    { source: 'src/vs/workbench/contrib/gomi', target: 'src/vs/workbench/contrib/gomi' },
+  ],
+  webviewAssetCopies: [
+    { source: 'build/gomi-office-webview', target: 'media/office' },
+  ],
+});
+
+describe('GomiCodeOssIntegrationSchema', () => {
+  it('accepts a valid manifest', () => {
+    const r = validateIntegrationManifest(validManifest());
+    expect(r.valid).toBe(true);
+    expect(r.errors).toEqual([]);
+  });
+
+  it('rejects missing productJson', () => {
+    const m = validManifest();
+    delete (m as any).productJson;
+    const r = validateIntegrationManifest(m);
+    expect(r.valid).toBe(false);
+  });
+
+  it('rejects missing moduleCopies', () => {
+    const m = validManifest();
+    delete (m as any).moduleCopies;
+    const r = validateIntegrationManifest(m);
+    expect(r.valid).toBe(false);
+  });
+
+  it('rejects empty moduleCopies array', () => {
+    const m = validManifest();
+    (m as any).moduleCopies = [];
+    const r = validateIntegrationManifest(m);
+    expect(r.valid).toBe(false);
+  });
+
+  it('rejects missing webviewAssetCopies', () => {
+    const m = validManifest();
+    delete (m as any).webviewAssetCopies;
+    const r = validateIntegrationManifest(m);
+    expect(r.valid).toBe(false);
+  });
+
+  it('rejects wrong schemaVersion', () => {
+    const m = validManifest();
+    (m as any).schemaVersion = 2;
+    const r = validateIntegrationManifest(m);
+    expect(r.valid).toBe(false);
+  });
+
+  it('rejects non-object input', () => {
+    expect(validateIntegrationManifest(null).valid).toBe(false);
+    expect(validateIntegrationManifest([]).valid).toBe(false);
+    expect(validateIntegrationManifest('string').valid).toBe(false);
+  });
+
+  it('rejects copy pair with missing source', () => {
+    const m = validManifest();
+    (m as any).moduleCopies = [{ target: 't' }];
+    const r = validateIntegrationManifest(m);
+    expect(r.valid).toBe(false);
+  });
+
+  it('accepts optional templateCopies and resourceCopies', () => {
+    const m = {
+      ...validManifest(),
+      templateCopies: [{ source: 'templates/a.ts', target: 'src/a.ts' }],
+      resourceCopies: [{ source: 'resources/icon.svg', target: 'icons/icon.svg' }],
+    };
+    const r = validateIntegrationManifest(m);
+    expect(r.valid).toBe(true);
+  });
+
+  it('rejects extra unknown keys', () => {
+    const m = { ...validManifest(), __evil: true };
+    const r = validateIntegrationManifest(m);
+    expect(r.valid).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
Adds a Zod schema validator for build/gomi-code-oss.integration.json with 10 tests.

### Acceptance Criteria
- [x] Invalid fixture fails (missing productJson, empty arrays, bad types)
- [x] Current repo manifest passes (valid structure)
- [x] Vitest coverage (10 tests)
- [x] Document how to extend (inline schema docs)

Closes #26