### PR TITLE
feat: keyboard shortcuts help overlay (press ? to toggle)

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1164,3 +1164,97 @@ button {
     border-top: 1px solid #1f2937;
   }
 }
+
+/* ===== Help Overlay ===== */
+.help-overlay-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.5);
+  backdrop-filter: blur(2px);
+}
+
+.help-overlay-card {
+  background: #1f2937;
+  border: 1px solid #374151;
+  border-radius: 12px;
+  padding: 24px;
+  min-width: 420px;
+  max-width: 90vw;
+  max-height: 80vh;
+  overflow-y: auto;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.5);
+}
+
+.help-overlay-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.help-overlay-header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  color: #f3f4f6;
+}
+
+.help-overlay-close {
+  background: none;
+  border: none;
+  color: #9ca3af;
+  font-size: 1.25rem;
+  cursor: pointer;
+  padding: 4px;
+  line-height: 1;
+}
+
+.help-overlay-close:hover {
+  color: #e5e7eb;
+}
+
+.help-overlay-body {
+  color: #d1d5db;
+}
+
+.help-overlay-body table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.help-overlay-body th {
+  text-align: left;
+  padding: 8px 12px;
+  border-bottom: 1px solid #374151;
+  color: #9ca3af;
+  font-weight: 600;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.help-overlay-body td {
+  padding: 8px 12px;
+  border-bottom: 1px solid #2d3748;
+}
+
+.help-overlay-body kbd {
+  display: inline-block;
+  background: #374151;
+  border: 1px solid #4b5563;
+  border-radius: 4px;
+  padding: 2px 6px;
+  font-family: monospace;
+  font-size: 0.85rem;
+  color: #e5e7eb;
+}
+
+.help-overlay-hint {
+  text-align: center;
+  margin-top: 16px;
+  font-size: 0.75rem;
+  color: #6b7280;
+}

--- a/src/vs/workbench/contrib/gomi/browser/GomiOfficeApp.tsx
+++ b/src/vs/workbench/contrib/gomi/browser/GomiOfficeApp.tsx
@@ -111,6 +111,7 @@ import {
   enqueueStatusToast,
   type GomiStatusToast
 } from './gomiStatusToasts';
+import { HelpOverlay } from './HelpOverlay';
 
 const activityItems = [
   { id: 'explorer', label: 'Explorer', Icon: Files },
@@ -871,6 +872,8 @@ export function GomiOfficeApp() {
         <span>{workbenchBridge ? 'Gomi Workbench Bridge' : 'Gomi Demo Runtime'}</span>
         <span>{isRunning ? 'Agents working' : 'Ready'}</span>
       </footer>
+
+      <HelpOverlay />
     </div>
   );
 }

--- a/src/vs/workbench/contrib/gomi/browser/HelpOverlay.tsx
+++ b/src/vs/workbench/contrib/gomi/browser/HelpOverlay.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useState, useCallback } from 'react';
+
+interface Shortcut {
+  keys: string;
+  description: string;
+}
+
+const DEFAULT_SHORTCUTS: Shortcut[] = [
+  { keys: '?', description: 'Toggle help overlay' },
+  { keys: 'Ctrl+E', description: 'Open terminal' },
+  { keys: 'Ctrl+P', description: 'Quick open file' },
+  { keys: 'Ctrl+Shift+P', description: 'Command palette' },
+  { keys: 'Ctrl+B', description: 'Toggle sidebar' },
+  { keys: 'Ctrl+`', description: 'Toggle terminal panel' },
+  { keys: 'Ctrl+K', description: 'Open keyboard shortcuts' },
+  { keys: 'Escape', description: 'Close current dialog' },
+];
+
+interface HelpOverlayProps {
+  shortcuts?: Shortcut[];
+  onVisibilityChange?: (visible: boolean) => void;
+}
+
+export function HelpOverlay({ shortcuts = DEFAULT_SHORTCUTS, onVisibilityChange }: HelpOverlayProps) {
+  const [visible, setVisible] = useState(false);
+
+  const toggle = useCallback(() => {
+    setVisible((prev) => {
+      const next = !prev;
+      onVisibilityChange?.(next);
+      return next;
+    });
+  }, [onVisibilityChange]);
+
+  const close = useCallback(() => {
+    setVisible(false);
+    onVisibilityChange?.(false);
+  }, [onVisibilityChange]);
+
+  useEffect(() => {
+    function handleKeydown(event: KeyboardEvent) {
+      const target = event.target as HTMLElement;
+      // Ignore key events inside input/textarea/contentEditable
+      if (
+        target.tagName === 'INPUT' ||
+        target.tagName === 'TEXTAREA' ||
+        target.isContentEditable
+      ) {
+        return;
+      }
+
+      if (event.key === '?' && !event.shiftKey) {
+        event.preventDefault();
+        toggle();
+      }
+
+      if (event.key === 'Escape' && visible) {
+        close();
+      }
+    }
+
+    document.addEventListener('keydown', handleKeydown);
+    return () => document.removeEventListener('keydown', handleKeydown);
+  }, [visible, toggle, close]);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      className="help-overlay-backdrop"
+      onClick={(e) => {
+        if ((e.target as HTMLElement).className === 'help-overlay-backdrop') {
+          close();
+        }
+      }}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Keyboard shortcuts help"
+    >
+      <div className="help-overlay-card">
+        <div className="help-overlay-header">
+          <h2>Keyboard Shortcuts</h2>
+          <button
+            className="help-overlay-close"
+            onClick={close}
+            aria-label="Close"
+            type="button"
+          >
+            ✕
+          </button>
+        </div>
+        <div className="help-overlay-body">
+          <table>
+            <thead>
+              <tr>
+                <th>Shortcut</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              {shortcuts.map((s, i) => (
+                <tr key={i}>
+                  <td><kbd>{s.keys}</kbd></td>
+                  <td>{s.description}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <p className="help-overlay-hint">
+            Press <kbd>?</kbd> or <kbd>Esc</kbd> to close
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Implements a keyboard shortcuts help overlay for Gomi IDE.

## Changes
- New `HelpOverlay.tsx` React component with dark theme styling
- Press `?` to toggle overlay, `Esc` to close
- Ignores key events inside input/textarea/contentEditable elements
- Configurable shortcut list via component props
- Integrated into `GomiOfficeApp` shell
- Dark theme CSS matching Gomi design system

## Usage
```tsx
import { HelpOverlay } from "./HelpOverlay";

// In your app shell:
<HelpOverlay />

// With custom shortcuts:
<HelpOverlay shortcuts={[
  { keys: "?", description: "Toggle help" },
  { keys: "Ctrl+S", description: "Save" },
]} />
```

Closes #76