### PR TITLE
Add recent projects launcher

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -194,6 +194,16 @@ button {
   color: #f9fafb;
 }
 
+.gomi-icon-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.42;
+}
+
+.gomi-icon-button:disabled:hover {
+  background: transparent;
+  color: #94a3b8;
+}
+
 .gomi-icon-button.is-danger {
   color: #fca5a5;
 }
@@ -480,6 +490,13 @@ button {
   align-items: center;
 }
 
+.gomi-project-row__head {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 30px;
+  align-items: center;
+  gap: 8px;
+}
+
 .gomi-agent-avatar {
   display: inline-grid;
   place-items: center;
@@ -515,6 +532,59 @@ button {
   color: #9ca3af;
   font-size: 12px;
   line-height: 1.45;
+}
+
+.gomi-recent-projects {
+  display: grid;
+  gap: 6px;
+}
+
+.gomi-recent-project {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 30px;
+  align-items: center;
+  gap: 6px;
+}
+
+.gomi-recent-project__main {
+  display: grid;
+  grid-template-columns: 18px minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  border: 1px solid #253247;
+  border-radius: 8px;
+  background: #111c2f;
+  color: #e5e7eb;
+  cursor: pointer;
+  padding: 7px 8px;
+  text-align: left;
+}
+
+.gomi-recent-project__main:hover {
+  border-color: #2dd4bf;
+}
+
+.gomi-recent-project__main span {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+
+.gomi-recent-project__main strong,
+.gomi-recent-project__main small {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.gomi-recent-project__main strong {
+  font-size: 12px;
+}
+
+.gomi-recent-project__main small {
+  color: #94a3b8;
+  font-size: 11px;
 }
 
 .gomi-status {

--- a/src/vs/workbench/contrib/gomi/browser/GomiOfficeApp.tsx
+++ b/src/vs/workbench/contrib/gomi/browser/GomiOfficeApp.tsx
@@ -10,6 +10,7 @@ import {
   Bed,
   FileDiff,
   Files,
+  FolderOpen,
   GitBranch,
   Maximize2,
   Minimize2,
@@ -29,7 +30,9 @@ import {
   Settings,
   ShieldCheck,
   Sparkles,
+  Star,
   Terminal,
+  Trash2,
   UserPlus,
   UserX,
   Users,
@@ -47,6 +50,8 @@ import {
   getProviderLabel,
   getSeatForAgent,
   hireEmployee,
+  rememberRecentProject,
+  removeRecentProject,
   setCliProvidersEnabled,
   setHttpProvidersEnabled,
   setHttpProviderMaxRetries,
@@ -82,6 +87,7 @@ import type {
   GomiMemoryEmbeddingProviderId,
   GomiMemoryPrivacyMode,
   GomiOfficeSettings,
+  GomiRecentProject,
   GomiRuntimeEvent,
   GomiTask,
   GomiWorkspaceTrustState,
@@ -552,6 +558,39 @@ export function GomiOfficeApp() {
     reader.readAsText(file);
   }
 
+  function rememberCurrentProject() {
+    const project = recentProjectFromWorkspace(workspace);
+
+    if (!project) {
+      return;
+    }
+
+    setOfficeSettings((currentSettings) => rememberRecentProject(currentSettings, project));
+  }
+
+  function openRecentProject(project: GomiRecentProject) {
+    const openedProject = {
+      ...project,
+      lastOpenedAt: new Date().toISOString()
+    };
+
+    setOfficeSettings((currentSettings) => rememberRecentProject(currentSettings, openedProject));
+
+    if (workbenchBridge) {
+      workbenchBridge.postMessage({
+        type: 'gomi.openProject',
+        project: openedProject
+      });
+      return;
+    }
+
+    setRequest(`Open recent project: ${project.name}\nPath: ${project.path}`);
+  }
+
+  function removeRecentProjectEntry(projectId: string) {
+    setOfficeSettings((currentSettings) => removeRecentProject(currentSettings, projectId));
+  }
+
   function assignProvider(seatId: string, providerId: GomiAgentCliProviderId) {
     setOfficeSettings((currentSettings) => assignSeatProvider(currentSettings, seatId, providerId));
   }
@@ -750,7 +789,14 @@ export function GomiOfficeApp() {
 
       <div className={workbenchClassName}>
         <ActivityBar />
-        <ProjectSidebar workspace={workspace} memoryItems={memoryItems} />
+        <ProjectSidebar
+          workspace={workspace}
+          memoryItems={memoryItems}
+          recentProjects={officeSettings.recentProjects}
+          onRememberCurrentProject={rememberCurrentProject}
+          onOpenRecentProject={openRecentProject}
+          onRemoveRecentProject={removeRecentProjectEntry}
+        />
 
         <main className={mainClassName}>
           <div className="gomi-tabs">
@@ -860,6 +906,8 @@ export function GomiOfficeApp() {
           onSimulateStaffing={simulateOfficeStaffing}
           onFireEmployee={fireOfficeEmployee}
           onRestoreEmployee={restoreOfficeEmployee}
+          onExportSettings={handleExportSettings}
+          onImportSettings={handleImportSettings}
           onBroadcastThresholdChange={updateBroadcastThreshold}
           onSharedMemoryEnabledChange={updateSharedMemoryEnabled}
           onWorkspaceContextIndexingChange={updateWorkspaceContextIndexing}
@@ -928,10 +976,18 @@ function ActivityBar() {
 
 function ProjectSidebar({
   workspace,
-  memoryItems
+  memoryItems,
+  recentProjects,
+  onRememberCurrentProject,
+  onOpenRecentProject,
+  onRemoveRecentProject
 }: {
   workspace?: GomiWorkspaceSnapshot;
   memoryItems: GomiMemoryBoardItem[];
+  recentProjects: GomiRecentProject[];
+  onRememberCurrentProject: () => void;
+  onOpenRecentProject: (project: GomiRecentProject) => void;
+  onRemoveRecentProject: (projectId: string) => void;
 }) {
   const files = workspace?.files ?? [
     'product.json',
@@ -965,6 +1021,26 @@ function ProjectSidebar({
         </div>
 
         <div className="gomi-project-row">
+          <div className="gomi-project-row__head">
+            <div className="gomi-project-name">Recent Projects</div>
+            <button
+              className="gomi-icon-button"
+              onClick={onRememberCurrentProject}
+              disabled={!workspace?.rootPath}
+              title="Save current project"
+              aria-label="Save current project"
+            >
+              <Star size={15} />
+            </button>
+          </div>
+          <RecentProjectsLauncher
+            recentProjects={recentProjects}
+            onOpenRecentProject={onOpenRecentProject}
+            onRemoveRecentProject={onRemoveRecentProject}
+          />
+        </div>
+
+        <div className="gomi-project-row">
           <div className="gomi-project-name">Agent Runtime</div>
           <div className="gomi-project-detail">
             CEO planner, message bus, event stream, patch proposal, final report.
@@ -980,6 +1056,48 @@ function ProjectSidebar({
   );
 }
 
+function RecentProjectsLauncher({
+  recentProjects,
+  onOpenRecentProject,
+  onRemoveRecentProject
+}: {
+  recentProjects: GomiRecentProject[];
+  onOpenRecentProject: (project: GomiRecentProject) => void;
+  onRemoveRecentProject: (projectId: string) => void;
+}) {
+  if (recentProjects.length === 0) {
+    return <div className="gomi-project-detail">No recent projects.</div>;
+  }
+
+  return (
+    <div className="gomi-recent-projects" aria-label="Recent Projects Launcher">
+      {recentProjects.map((project) => (
+        <div className="gomi-recent-project" key={project.id}>
+          <button
+            className="gomi-recent-project__main"
+            onClick={() => onOpenRecentProject(project)}
+            title={`Open ${project.name}`}
+          >
+            <FolderOpen size={16} />
+            <span>
+              <strong>{project.name}</strong>
+              <small>{project.path}</small>
+            </span>
+          </button>
+          <button
+            className="gomi-icon-button"
+            onClick={() => onRemoveRecentProject(project.id)}
+            title={`Remove ${project.name}`}
+            aria-label={`Remove ${project.name}`}
+          >
+            <Trash2 size={15} />
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 function RightPanel({
   agents,
   tasks,
@@ -989,6 +1107,8 @@ function RightPanel({
   memoryPruneReport,
   memoryPruneError,
   isPruningMemory,
+  onExportSettings,
+  onImportSettings,
   onProviderChange,
   onToggleSeatSleep,
   onClosePanel,
@@ -1031,6 +1151,8 @@ function RightPanel({
   onSimulateStaffing: () => void;
   onFireEmployee: (seatId: string) => void;
   onRestoreEmployee: (seatId: string) => void;
+  onExportSettings: () => void;
+  onImportSettings: (file: File) => void;
   onBroadcastThresholdChange: (broadcastThreshold: number) => void;
   onSharedMemoryEnabledChange: (sharedMemoryEnabled: boolean) => void;
   onWorkspaceContextIndexingChange: (indexWorkspaceContext: boolean) => void;
@@ -1094,8 +1216,8 @@ function RightPanel({
           memoryPruneReport={memoryPruneReport}
           memoryPruneError={memoryPruneError}
           isPruningMemory={isPruningMemory}
-          onExportSettings={handleExportSettings}
-          onImportSettings={handleImportSettings}
+          onExportSettings={onExportSettings}
+          onImportSettings={onImportSettings}
           onProviderChange={onProviderChange}
           onToggleSeatSleep={onToggleSeatSleep}
           onHireEmployee={onHireEmployee}
@@ -1218,6 +1340,8 @@ function OfficeSettingsPanel({
   memoryPruneReport,
   memoryPruneError,
   isPruningMemory,
+  onExportSettings,
+  onImportSettings,
   onProviderChange,
   onToggleSeatSleep,
   onHireEmployee,
@@ -1997,6 +2121,19 @@ function applyOfficeSettingsToAgents(
 
     return agent;
   });
+}
+
+function recentProjectFromWorkspace(
+  workspace: GomiWorkspaceSnapshot | undefined
+): Pick<GomiRecentProject, 'name' | 'path'> | undefined {
+  if (!workspace?.rootPath) {
+    return undefined;
+  }
+
+  return {
+    name: workspace.rootName,
+    path: workspace.rootPath
+  };
 }
 
 function iconForAgent(agentId: GomiAgentId) {

--- a/src/vs/workbench/contrib/gomi/browser/codeOssWorkspaceServices.ts
+++ b/src/vs/workbench/contrib/gomi/browser/codeOssWorkspaceServices.ts
@@ -323,12 +323,21 @@ export async function readCodeOssWorkspaceSnapshot(
 
   return {
     rootName,
+    rootPath: folderPath(folders[0]),
     files: files.slice(0, resolvedOptions.maxFiles),
     openEditors,
     gitSummary: scmContext.summary,
     terminalSummary: `Indexed through Code - OSS workspace, editor, marker, terminal, SCM, file, and text-file services. ${selectionSnippets.length} selection snippet(s), ${diagnosticSnippets.length} diagnostic snippet(s), ${terminalSnippets.length} terminal snippet(s), ${scmContext.snippets.length} git diff snippet(s), ${errorLogSnippets.length} error-log snippet(s), ${contentSnippets.length} file snippet(s) loaded.`,
     contentSnippets: allContentSnippets
   };
+}
+
+function folderPath(folder: GomiCodeOssWorkspaceFolder | undefined): string | undefined {
+  if (!folder) {
+    return undefined;
+  }
+
+  return folder.uri.fsPath ?? folder.uri.path ?? folder.uri.toString(true);
 }
 
 export async function applyCodeOssPatchMessage(

--- a/src/vs/workbench/contrib/gomi/browser/gomiWebviewBridge.ts
+++ b/src/vs/workbench/contrib/gomi/browser/gomiWebviewBridge.ts
@@ -10,6 +10,7 @@ import type {
   GomiPatchApprovalStatus,
   GomiPatchProposal,
   GomiPatchRiskLevel,
+  GomiRecentProject,
   GomiWorkspaceTrustState
 } from '../common/gomiTypes';
 import {
@@ -151,6 +152,7 @@ const GOMI_MEMORY_EMBEDDING_PROVIDERS: readonly GomiMemoryEmbeddingProviderId[] 
   'ollama-embed'
 ];
 const GOMI_MEMORY_PRIVACY_MODES: readonly GomiMemoryPrivacyMode[] = ['standard', 'strict'];
+const GOMI_AVATAR_STYLES = ['emoji', 'geometric', 'initials'] as const;
 const GOMI_WORKSPACE_TRUST_STATES: readonly GomiWorkspaceTrustState[] = ['trusted', 'untrusted'];
 const GOMI_LIVE_PROVIDER_MODES: readonly GomiLiveProviderMode[] = [
   'demo-only',
@@ -210,6 +212,8 @@ export function isGomiBridgeMessage(value: unknown): value is GomiBridgeMessage 
         hasOnlyKeys(value, ['protocolVersion', 'type', 'officeSettings']) &&
         isOptionalOfficeSettings(value.officeSettings)
       );
+    case 'gomi.openProject':
+      return hasOnlyKeys(value, ['protocolVersion', 'type', 'project']) && isRecentProject(value.project);
     case 'gomi.applyPatch':
     case 'gomi.previewPatch':
       return hasOnlyKeys(value, ['protocolVersion', 'type', 'patch']) && isPatchProposal(value.patch);
@@ -301,16 +305,42 @@ function isPatchProposal(value: unknown): value is GomiPatchProposal {
   );
 }
 
+function isRecentProject(value: unknown): value is GomiRecentProject {
+  if (
+    !isRecord(value) ||
+    !hasOnlyKeys(value, ['id', 'name', 'path', 'lastOpenedAt'])
+  ) {
+    return false;
+  }
+
+  return (
+    isSafeString(value.id, 128) &&
+    isSafeString(value.name, 120) &&
+    isSafeProjectPath(value.path) &&
+    isSafeString(value.lastOpenedAt, 64)
+  );
+}
+
 function isOptionalOfficeSettings(value: unknown): boolean {
   if (value === undefined) {
     return true;
   }
 
-  if (!isRecord(value) || !hasOnlyKeys(value, ['seats', 'memory', 'execution'])) {
+  if (!isRecord(value) || !hasOnlyKeys(value, ['avatarStyle', 'recentProjects', 'seats', 'memory', 'execution'])) {
     return false;
   }
 
-  return isSeatArray(value.seats) && isMemorySettings(value.memory) && isExecutionSettings(value.execution);
+  return (
+    (value.avatarStyle === undefined || isOneOf(value.avatarStyle, GOMI_AVATAR_STYLES)) &&
+    (value.recentProjects === undefined || isRecentProjectArray(value.recentProjects)) &&
+    isSeatArray(value.seats) &&
+    isMemorySettings(value.memory) &&
+    isExecutionSettings(value.execution)
+  );
+}
+
+function isRecentProjectArray(value: unknown): value is GomiRecentProject[] {
+  return Array.isArray(value) && value.length <= 8 && value.every(isRecentProject);
 }
 
 function isSeatArray(value: unknown): value is GomiAgentSeat[] {
@@ -394,7 +424,8 @@ function isExecutionSettings(value: unknown): boolean {
       'allowCliProviders',
       'allowHttpProviders',
       'requirePatchApprovalForLiveProviders',
-      'maxConcurrentAgentRuns'
+      'maxConcurrentAgentRuns',
+      'httpMaxRetries'
     ])
   ) {
     return false;
@@ -406,7 +437,8 @@ function isExecutionSettings(value: unknown): boolean {
     typeof value.allowCliProviders === 'boolean' &&
     typeof value.allowHttpProviders === 'boolean' &&
     typeof value.requirePatchApprovalForLiveProviders === 'boolean' &&
-    isNumberInRange(value.maxConcurrentAgentRuns, 1, 16)
+    isNumberInRange(value.maxConcurrentAgentRuns, 1, 16) &&
+    (value.httpMaxRetries === undefined || isNumberInRange(value.httpMaxRetries, 0, 10))
   );
 }
 
@@ -438,6 +470,10 @@ function isSafeRelativePath(value: unknown): value is string {
   }
 
   return normalized.split('/').every((segment) => segment.length > 0 && segment !== '.' && segment !== '..');
+}
+
+function isSafeProjectPath(value: unknown): value is string {
+  return isSafeString(value, 500) && !value.includes('\0');
 }
 
 function isNumberInRange(value: unknown, min: number, max: number): value is number {

--- a/src/vs/workbench/contrib/gomi/browser/gomiWebviewHostController.ts
+++ b/src/vs/workbench/contrib/gomi/browser/gomiWebviewHostController.ts
@@ -24,6 +24,9 @@ export interface GomiWebviewHostControllerOptions {
   patchPreviewer?: (
     message: Extract<GomiBridgeMessage, { type: 'gomi.previewPatch' }>
   ) => Promise<GomiPatchPreviewResult>;
+  projectOpener?: (
+    message: Extract<GomiBridgeMessage, { type: 'gomi.openProject' }>
+  ) => Promise<void>;
   runtimeOptions?: GomiRuntimeOptions;
 }
 
@@ -67,6 +70,11 @@ export class GomiWebviewHostController {
 
     if (message.type === 'gomi.pruneMemory') {
       await this.pruneMemory(message);
+      return;
+    }
+
+    if (message.type === 'gomi.openProject') {
+      await this.openProject(message);
       return;
     }
 
@@ -150,6 +158,19 @@ export class GomiWebviewHostController {
         type: 'gomi.pruneMemoryResult',
         error: error instanceof Error ? error.message : 'Unknown memory prune error.'
       });
+    }
+  }
+
+  private async openProject(message: Extract<GomiBridgeMessage, { type: 'gomi.openProject' }>): Promise<void> {
+    try {
+      if (!this.options.projectOpener) {
+        throw new Error('Recent project opening is not configured for this Gomi webview host.');
+      }
+
+      await this.options.projectOpener(message);
+      this.postSystemMessage(`Opening recent project: ${message.project.name}.`);
+    } catch (error) {
+      this.postSystemMessage(error instanceof Error ? error.message : 'Unknown recent project open error.');
     }
   }
 

--- a/src/vs/workbench/contrib/gomi/common/gomiOfficeSettings.ts
+++ b/src/vs/workbench/contrib/gomi/common/gomiOfficeSettings.ts
@@ -9,6 +9,7 @@ import type {
   GomiMemoryEmbeddingProviderId,
   GomiMemoryPrivacyMode,
   GomiOfficeSettings,
+  GomiRecentProject,
   GomiWorkspaceTrustState
 } from './gomiTypes';
 
@@ -17,6 +18,7 @@ export const GOMI_DEFAULT_MEMORY_RETENTION_DAYS = 30;
 export const GOMI_DEFAULT_MAX_PROJECT_MEMORY_ITEMS = 420;
 export const GOMI_DEFAULT_MAX_CONCURRENT_AGENT_RUNS = 2;
 export const GOMI_DEFAULT_HTTP_MAX_RETRIES = 2;
+export const GOMI_MAX_RECENT_PROJECTS = 8;
 
 export const GOMI_AVATAR_STYLE_OPTIONS: Array<{
   id: GomiAvatarStyle;
@@ -181,6 +183,7 @@ export const GOMI_AGENT_CLI_PROVIDERS: GomiAgentCliProvider[] = [
 
 export const DEFAULT_GOMI_OFFICE_SETTINGS: GomiOfficeSettings = {
   avatarStyle: 'emoji',
+  recentProjects: [],
   seats: [
     {
       id: 'seat-ceo',
@@ -404,6 +407,36 @@ export function setAvatarStyle(
   };
 }
 
+export function rememberRecentProject(
+  settings: GomiOfficeSettings,
+  project: Pick<GomiRecentProject, 'name' | 'path'> & Partial<Pick<GomiRecentProject, 'lastOpenedAt'>>,
+  lastOpenedAt = new Date().toISOString()
+): GomiOfficeSettings {
+  const recentProject = normalizeRecentProject({
+    ...project,
+    lastOpenedAt
+  });
+
+  if (!recentProject) {
+    return settings;
+  }
+
+  return {
+    ...settings,
+    recentProjects: [
+      recentProject,
+      ...settings.recentProjects.filter((item) => item.path !== recentProject.path)
+    ].slice(0, GOMI_MAX_RECENT_PROJECTS)
+  };
+}
+
+export function removeRecentProject(settings: GomiOfficeSettings, projectId: string): GomiOfficeSettings {
+  return {
+    ...settings,
+    recentProjects: settings.recentProjects.filter((project) => project.id !== projectId)
+  };
+}
+
 export function setPatchApprovalRequired(
   settings: GomiOfficeSettings,
   requirePatchApproval: boolean
@@ -513,6 +546,7 @@ export function normalizeGomiOfficeSettings(value: unknown): GomiOfficeSettings 
   let normalizedSettings: GomiOfficeSettings = {
     ...DEFAULT_GOMI_OFFICE_SETTINGS,
     avatarStyle: avatarStyleSetting(rawSettings.avatarStyle),
+    recentProjects: normalizeRecentProjects(rawSettings.recentProjects),
     seats: normalizeSeatSettings(rawSettings.seats)
   };
   const rawMemory: Record<string, unknown> = isRecord(rawSettings.memory) ? rawSettings.memory : {};
@@ -776,6 +810,70 @@ function normalizeAdditionalEmployeeSeats(
   return normalizedSeats;
 }
 
+function normalizeRecentProjects(value: unknown): GomiRecentProject[] {
+  if (!Array.isArray(value)) {
+    return DEFAULT_GOMI_OFFICE_SETTINGS.recentProjects;
+  }
+
+  const seenPaths = new Set<string>();
+  const normalizedProjects: GomiRecentProject[] = [];
+
+  for (const rawProject of value.filter(isRecord)) {
+    const project = normalizeRecentProject(rawProject);
+
+    if (!project || seenPaths.has(project.path)) {
+      continue;
+    }
+
+    normalizedProjects.push(project);
+    seenPaths.add(project.path);
+
+    if (normalizedProjects.length >= GOMI_MAX_RECENT_PROJECTS) {
+      break;
+    }
+  }
+
+  return normalizedProjects;
+}
+
+function normalizeRecentProject(value: unknown): GomiRecentProject | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  const path = trimBoundedString(value.path, 500);
+
+  if (!path || path.includes('\0')) {
+    return undefined;
+  }
+
+  const name = trimBoundedString(value.name, 120) ?? nameFromProjectPath(path);
+  const lastOpenedAt = trimBoundedString(value.lastOpenedAt, 64) ?? new Date(0).toISOString();
+
+  return {
+    id: `project-${stableProjectHash(path)}`,
+    name,
+    path,
+    lastOpenedAt
+  };
+}
+
+function nameFromProjectPath(path: string): string {
+  const segments = path.replace(/\\/g, '/').split('/').filter(Boolean);
+  return trimBoundedString(segments.at(-1), 120) ?? path;
+}
+
+function stableProjectHash(path: string): string {
+  let hash = 2166136261;
+
+  for (const character of path) {
+    hash ^= character.charCodeAt(0);
+    hash = Math.imul(hash, 16777619);
+  }
+
+  return (hash >>> 0).toString(36);
+}
+
 function agentProviderSetting(value: unknown, fallback: GomiAgentCliProviderId): GomiAgentCliProviderId {
   return GOMI_AGENT_CLI_PROVIDERS.some((provider) => provider.id === value)
     ? value as GomiAgentCliProviderId
@@ -865,6 +963,16 @@ function booleanSetting(value: unknown, fallback: boolean): boolean {
 
 function numberSetting(value: unknown, fallback: number): number {
   return typeof value === 'number' && Number.isFinite(value) ? value : fallback;
+}
+
+function trimBoundedString(value: unknown, maxLength: number): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+
+  return trimmed.length > 0 ? trimmed.slice(0, maxLength) : undefined;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/vs/workbench/contrib/gomi/common/gomiTypes.ts
+++ b/src/vs/workbench/contrib/gomi/common/gomiTypes.ts
@@ -104,8 +104,16 @@ export interface GomiOfficeExecutionSettings {
   httpMaxRetries: number;
 }
 
+export interface GomiRecentProject {
+  id: string;
+  name: string;
+  path: string;
+  lastOpenedAt: string;
+}
+
 export interface GomiOfficeSettings {
   avatarStyle: GomiAvatarStyle;
+  recentProjects: GomiRecentProject[];
   seats: GomiAgentSeat[];
   memory: GomiOfficeMemorySettings;
   execution: GomiOfficeExecutionSettings;
@@ -201,6 +209,7 @@ export interface GomiPatchPreviewResult {
 
 export interface GomiWorkspaceSnapshot {
   rootName: string;
+  rootPath?: string;
   files: string[];
   openEditors: string[];
   gitSummary: string;

--- a/src/vs/workbench/contrib/gomi/electron-sandbox/gomiBridge.ts
+++ b/src/vs/workbench/contrib/gomi/electron-sandbox/gomiBridge.ts
@@ -2,6 +2,7 @@ import type {
   GomiOfficeSettings,
   GomiPatchPreviewResult,
   GomiPatchProposal,
+  GomiRecentProject,
   GomiRuntimeEvent
 } from '../common/gomiTypes';
 import type { GomiRuntimeMemoryPruneReport } from '../node/agentRuntime';
@@ -26,6 +27,10 @@ export type GomiBridgeMessage = {
   | {
       type: 'gomi.pruneMemory';
       officeSettings?: GomiOfficeSettings;
+    }
+  | {
+      type: 'gomi.openProject';
+      project: GomiRecentProject;
     }
   | {
       type: 'gomi.pruneMemoryResult';

--- a/src/vs/workbench/contrib/gomi/node/nodeWorkspaceReader.ts
+++ b/src/vs/workbench/contrib/gomi/node/nodeWorkspaceReader.ts
@@ -46,6 +46,7 @@ export async function readNodeWorkspaceSnapshot(
 
   return {
     rootName,
+    rootPath: path.resolve(workspaceRoot),
     files: [...importantFiles, ...files.filter((file) => !importantFiles.includes(file))].slice(0, maxFiles),
     openEditors: options.openEditors ?? importantFiles.slice(0, 4),
     gitSummary,

--- a/src/vs/workbench/contrib/gomi/node/workspaceReader.ts
+++ b/src/vs/workbench/contrib/gomi/node/workspaceReader.ts
@@ -7,6 +7,7 @@ export type GomiWorkspaceSnapshotReader = () =>
 export function createDemoWorkspaceSnapshot(rootName = 'Gomi'): GomiWorkspaceSnapshot {
   return {
     rootName,
+    rootPath: '.',
     files: [
       'product.json',
       'package.json',

--- a/tests/gomiOfficeSettingsPersistence.test.ts
+++ b/tests/gomiOfficeSettingsPersistence.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
   DEFAULT_GOMI_OFFICE_SETTINGS,
+  GOMI_MAX_RECENT_PROJECTS,
+  rememberRecentProject,
+  removeRecentProject,
   setAvatarStyle,
   setMemoryEmbeddingExecutionEnabled,
   setMemoryEmbeddingProvider,
@@ -39,7 +42,14 @@ describe('Gomi office settings persistence', () => {
   it('falls back to browser local storage for the standalone office demo', () => {
     const localStorage = new MemoryLocalStorage();
     const settings = setAvatarStyle(
-      setSeatWorkMode(DEFAULT_GOMI_OFFICE_SETTINGS, 'head-frontend', 'sleeping'),
+      rememberRecentProject(
+        setSeatWorkMode(DEFAULT_GOMI_OFFICE_SETTINGS, 'head-frontend', 'sleeping'),
+        {
+          name: 'Gomi IDE',
+          path: '/workspaces/gomi'
+        },
+        '2026-07-15T09:30:00.000Z'
+      ),
       'initials'
     );
 
@@ -49,6 +59,14 @@ describe('Gomi office settings persistence', () => {
 
     expect(restoredSettings.seats.find((seat) => seat.id === 'head-frontend')?.workMode).toBe('sleeping');
     expect(restoredSettings.avatarStyle).toBe('initials');
+    expect(restoredSettings.recentProjects).toEqual([
+      {
+        id: 'project-4a4cdx',
+        name: 'Gomi IDE',
+        path: '/workspaces/gomi',
+        lastOpenedAt: '2026-07-15T09:30:00.000Z'
+      }
+    ]);
   });
 
   it('normalizes corrupted persisted payloads back to safe defaults', () => {
@@ -57,6 +75,42 @@ describe('Gomi office settings persistence', () => {
     localStorage.setItem('gomi.office.settings.v1', '{not-json');
 
     expect(loadPersistedOfficeSettings({ localStorage })).toEqual(DEFAULT_GOMI_OFFICE_SETTINGS);
+  });
+
+  it('keeps recent projects deduplicated, bounded, and removable', () => {
+    let settings = DEFAULT_GOMI_OFFICE_SETTINGS;
+
+    for (let index = 0; index < GOMI_MAX_RECENT_PROJECTS + 2; index += 1) {
+      settings = rememberRecentProject(
+        settings,
+        {
+          name: `Project ${index}`,
+          path: `/workspace/project-${index}`
+        },
+        `2026-07-15T10:${String(index).padStart(2, '0')}:00.000Z`
+      );
+    }
+
+    settings = rememberRecentProject(
+      settings,
+      {
+        name: 'Project 3 renamed',
+        path: '/workspace/project-3'
+      },
+      '2026-07-15T11:00:00.000Z'
+    );
+
+    expect(settings.recentProjects).toHaveLength(GOMI_MAX_RECENT_PROJECTS);
+    expect(settings.recentProjects[0]).toMatchObject({
+      name: 'Project 3 renamed',
+      path: '/workspace/project-3',
+      lastOpenedAt: '2026-07-15T11:00:00.000Z'
+    });
+    expect(settings.recentProjects.filter((project) => project.path === '/workspace/project-3')).toHaveLength(1);
+
+    const withoutProject = removeRecentProject(settings, settings.recentProjects[0].id);
+
+    expect(withoutProject.recentProjects.some((project) => project.path === '/workspace/project-3')).toBe(false);
   });
 });
 

--- a/tests/gomiWebviewBridge.test.ts
+++ b/tests/gomiWebviewBridge.test.ts
@@ -47,6 +47,15 @@ describe('Gomi webview bridge', () => {
       type: 'gomi.stop',
       reason: 'Stop bridge test'
     });
+    bridge?.postMessage({
+      type: 'gomi.openProject',
+      project: {
+        id: 'project-gomi',
+        name: 'Gomi IDE',
+        path: '/workspaces/gomi',
+        lastOpenedAt: '2026-07-15T10:00:00.000Z'
+      }
+    });
     target.emit({
       protocolVersion: 1,
       type: 'gomi.applyPatchResult',
@@ -76,6 +85,16 @@ describe('Gomi webview bridge', () => {
         protocolVersion: 1,
         type: 'gomi.stop',
         reason: 'Stop bridge test'
+      },
+      {
+        protocolVersion: 1,
+        type: 'gomi.openProject',
+        project: {
+          id: 'project-gomi',
+          name: 'Gomi IDE',
+          path: '/workspaces/gomi',
+          lastOpenedAt: '2026-07-15T10:00:00.000Z'
+        }
       }
     ]);
     expect(received).toHaveLength(1);
@@ -131,6 +150,29 @@ describe('Gomi webview bridge', () => {
     expect(isGomiBridgeMessage({ protocolVersion: 1, type: 'gomi.danger' })).toBe(false);
     expect(isGomiBridgeMessage({ protocolVersion: 1, type: 'workspace.event' })).toBe(false);
     expect(isGomiBridgeMessage(undefined)).toBe(false);
+  });
+
+  it('validates recent-project open messages at the webview boundary', () => {
+    expect(isGomiBridgeMessage({
+      protocolVersion: 1,
+      type: 'gomi.openProject',
+      project: {
+        id: 'project-gomi',
+        name: 'Gomi IDE',
+        path: '/workspaces/gomi',
+        lastOpenedAt: '2026-07-15T10:00:00.000Z'
+      }
+    })).toBe(true);
+    expect(isGomiBridgeMessage({
+      protocolVersion: 1,
+      type: 'gomi.openProject',
+      project: {
+        id: 'project-bad',
+        name: 'Bad Project',
+        path: 'bad\u0000path',
+        lastOpenedAt: '2026-07-15T10:00:00.000Z'
+      }
+    })).toBe(false);
   });
 
   it('rejects malformed or oversized privileged webview payloads', () => {

--- a/tests/gomiWebviewHostController.test.ts
+++ b/tests/gomiWebviewHostController.test.ts
@@ -168,6 +168,39 @@ describe('Gomi webview host controller', () => {
     });
   });
 
+  it('opens a recent project through the configured host opener', async () => {
+    const bridge = new MemoryBridge();
+    const openedProjects: string[] = [];
+    const controller = new GomiWebviewHostController({
+      bridge,
+      projectOpener: async (message) => {
+        openedProjects.push(message.project.path);
+      }
+    });
+
+    await controller.handleMessage({
+      type: 'gomi.openProject',
+      project: {
+        id: 'project-gomi',
+        name: 'Gomi IDE',
+        path: '/workspaces/gomi',
+        lastOpenedAt: '2026-07-15T10:00:00.000Z'
+      }
+    });
+
+    expect(openedProjects).toEqual(['/workspaces/gomi']);
+    expect(bridge.outbox[0]).toMatchObject({
+      type: 'gomi.event',
+      event: {
+        type: 'message',
+        message: {
+          senderName: 'Gomi System',
+          content: 'Opening recent project: Gomi IDE.'
+        }
+      }
+    });
+  });
+
   it('returns patch apply errors when no host patch applier is configured', async () => {
     const bridge = new MemoryBridge();
     const controller = new GomiWebviewHostController({ bridge });


### PR DESCRIPTION
## Summary
- Adds a bounded recent-projects launcher to the Gomi Office sidebar so users can save, reopen, and remove recently used workspaces.
- Persists recent projects in office settings with dedupe, cap, and backward-compatible defaults.
- Wires the webview/native bridge and host controller for validated `gomi.openProject` requests.

Closes #77
Refs mergeos-bounties/mergeos#244

## Problem
Gomi Office did not expose a recent-projects list or an open action, so users had no in-app path to return to a prior workspace from the office launcher.

## Implementation notes
- Adds `recentProjects` settings helpers, bounded persistence, and workspace `rootPath` metadata.
- Adds sidebar UI controls for saving the current project, opening a saved project, and removing saved entries.
- Adds bridge validation and a host `projectOpener` hook for native project-open requests.
- In standalone demo mode, opening a recent project rewrites the project request text area so the behavior remains observable without a native host.

## Verification
- `npm ci` passed; npm reported existing deprecation warnings and 11 high severity audit findings.
- `npm test -- tests/gomiOfficeSettingsPersistence.test.ts tests/gomiWebviewBridge.test.ts tests/gomiWebviewHostController.test.ts tests/codeOssWorkspaceServices.test.ts tests/nodeWorkspaceReader.test.ts tests/gomiOfficeLayout.test.ts` passed: 6 files, 34 tests.
- Standalone Playwright smoke passed: save current project, launcher shows `Gomi` with path `.`, opening the row rewrites the textarea to `Open recent project: Gomi` / `Path: .`, with no console or page errors.
- Native-webview bridge smoke passed: opening saved `Demo Workspace` posted one `gomi.openProject` message with `protocolVersion: 1` and path `/workspace/demo`, with no console or page errors.
- `git diff --check HEAD~1..HEAD` passed.
- Git identity verified for the branch commit: author and committer are `Rajesh Digambar Bagul <102693488+Rajesh270712@users.noreply.github.com>`.

## Risk and rollback
- Native project opening depends on the embedding host supplying `projectOpener`; without it, the host reports a system error instead of silently opening a project.
- Full baseline gates are currently red before this patch: `npm run typecheck`, `npm run build`, and full `npm test` fail on existing missing `zod` / Mocha-global test issues plus unrelated TypeScript errors outside this change surface.
- Rollback is a straight revert of this PR; it only affects Gomi recent-project settings, UI, bridge, host, workspace metadata, and tests.

## Maintainer notes
- The focused tests and smoke checks above cover the new recent-project launcher behavior.
- I did not add dependencies or change the lockfile.
