### PR TITLE
feat(electron): optional auto-update stub (off by default) (#29, 50 MRG)

### DIFF
--- a/docs/windows-release.md
+++ b/docs/windows-release.md
@@ -146,6 +146,33 @@ The product release artifact should be a Windows desktop package from the Code -
 
 VS Code's Windows setup path uses Inno Setup. MSI is not the primary upstream packaging format, so Gomi should target a setup `.exe` first and add MSI only if an enterprise installer pipeline is introduced later.
 
+## Optional Electron auto-update (off by default)
+
+The prototype Electron shell (`electron/main.cjs`) includes **optional** auto-update plumbing for packaged builds. It is intentionally inert unless operators opt in.
+
+Policy helper: `electron/shouldCheckForUpdates.cjs` (unit-tested via `tests/shouldCheckForUpdates.test.ts`).
+
+| Condition | Result |
+| --- | --- |
+| Unpackaged / dev (`app.isPackaged === false`) | No update check |
+| Packaged, default env | No update check — **no network** |
+| Packaged + `GOMI_AUTO_UPDATE=1` but no feed URL | No update check |
+| Packaged + flag + non-HTTPS feed | Rejected (`feed-url-not-https`) |
+| Packaged + `GOMI_AUTO_UPDATE=1` + `GOMI_UPDATE_FEED_URL=https://…` | May call `electron-updater` once with `autoDownload=false` |
+
+Env flags:
+
+- `GOMI_AUTO_UPDATE` — set to `1`, `true`, or `yes` to opt in. Anything else (including unset) keeps updates off.
+- `GOMI_UPDATE_FEED_URL` — HTTPS base URL for a generic update feed. Required when the flag is on.
+
+Security notes for packaging:
+
+- **Default packaged builds never call the network for updates.** CI and release artifacts must not set `GOMI_AUTO_UPDATE` unless a production feed is intentionally configured.
+- `electron-updater` is an **optional** runtime peer. It is not a hard dependency of this repository; if the module is missing, the main process skips the check instead of crashing.
+- Only **HTTPS** feeds are accepted so a mis-set env cannot force plaintext or local schemes.
+- When a check runs, `autoDownload` stays `false` so a compromised or unexpected feed cannot silently replace binaries without an explicit download path (future work).
+- Prefer code-signing the release artifacts and serving the feed from a controlled origin before enabling this in production.
+
 ## Current Limitation
 
 This repository is still a Gomi product foundation and module scaffold. A full release requires validating the native workbench contribution and patch diff preview inside a real Code - OSS fork, deepening terminal scrollback and workbench log/output-channel readers beyond the current adapter hooks, and replacing all final branding assets.

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1,9 +1,50 @@
 const { app, BrowserWindow, shell, Menu } = require('electron');
 const path = require('node:path');
 const { resolveRendererEntry } = require('./resolveRendererEntry.cjs');
+const { shouldCheckForUpdates } = require('./shouldCheckForUpdates.cjs');
 
 const isDev = !app.isPackaged;
 const rendererEntry = path.join(__dirname, '..', 'dist', 'index.html');
+
+/**
+ * Optional auto-update wiring. electron-updater is not a hard dependency;
+ * default packaged builds never touch the network for updates (see
+ * shouldCheckForUpdates). When enabled + HTTPS feed is set, we try a
+ * dynamic require and a single check with autoDownload=false.
+ *
+ * @returns {{ allowed: boolean, reason: string, feedUrl?: string, attempted?: boolean, error?: string }}
+ */
+function maybeInitAutoUpdate() {
+  const policy = shouldCheckForUpdates({
+    isPackaged: app.isPackaged,
+    env: process.env
+  });
+
+  if (!policy.allowed) {
+    return policy;
+  }
+
+  try {
+    // Optional peer: not listed in package.json so default installs stay offline.
+    // eslint-disable-next-line import/no-extraneous-dependencies, global-require
+    const { autoUpdater } = require('electron-updater');
+    autoUpdater.autoDownload = false;
+    autoUpdater.setFeedURL({
+      provider: 'generic',
+      url: policy.feedUrl
+    });
+    void autoUpdater.checkForUpdates().catch(() => {
+      // Network/feed errors are non-fatal; packaging must not crash on update fail.
+    });
+    return { ...policy, attempted: true };
+  } catch (err) {
+    return {
+      ...policy,
+      attempted: false,
+      error: err && err.message ? String(err.message) : 'electron-updater-unavailable'
+    };
+  }
+}
 
 function createWindow() {
   const window = new BrowserWindow({
@@ -68,6 +109,9 @@ app.whenReady().then(() => {
   if (!isDev) {
     Menu.setApplicationMenu(null);
   }
+
+  // Policy runs before window create; default is no network call.
+  maybeInitAutoUpdate();
 
   createWindow();
 

--- a/electron/shouldCheckForUpdates.cjs
+++ b/electron/shouldCheckForUpdates.cjs
@@ -1,0 +1,75 @@
+/**
+ * Pure policy: decide whether the packaged Electron main process may attempt
+ * an auto-update network check. Default is OFF — no network unless both the
+ * opt-in flag and a trusted HTTPS feed URL are present.
+ *
+ * Env:
+ *   GOMI_AUTO_UPDATE=1|true|yes  — explicit opt-in (default off)
+ *   GOMI_UPDATE_FEED_URL=https://… — generic update feed base URL
+ *
+ * electron-updater itself is optional; this helper only answers "may we check?".
+ *
+ * @param {{
+ *   isPackaged: boolean,
+ *   env?: NodeJS.ProcessEnv | Record<string, string | undefined>,
+ *   updateFeedUrl?: string | null
+ * }} options
+ * @returns {{
+ *   allowed: boolean,
+ *   reason: string,
+ *   feedUrl?: string
+ * }}
+ */
+function shouldCheckForUpdates(options) {
+  const env = options.env || {};
+
+  if (!options.isPackaged) {
+    return {
+      allowed: false,
+      reason: 'not-packaged'
+    };
+  }
+
+  const flag = String(env.GOMI_AUTO_UPDATE || '')
+    .trim()
+    .toLowerCase();
+  const wantsUpdate =
+    flag === '1' || flag === 'true' || flag === 'yes';
+
+  if (!wantsUpdate) {
+    return {
+      allowed: false,
+      reason: 'flag-disabled'
+    };
+  }
+
+  const feedUrl = String(
+    options.updateFeedUrl || env.GOMI_UPDATE_FEED_URL || ''
+  ).trim();
+
+  if (!feedUrl) {
+    return {
+      allowed: false,
+      reason: 'missing-feed-url'
+    };
+  }
+
+  // Only HTTPS feeds are accepted so a misconfigured env cannot point
+  // packaged builds at plaintext or local schemes.
+  if (!/^https:\/\//i.test(feedUrl)) {
+    return {
+      allowed: false,
+      reason: 'feed-url-not-https'
+    };
+  }
+
+  return {
+    allowed: true,
+    reason: 'enabled',
+    feedUrl
+  };
+}
+
+module.exports = {
+  shouldCheckForUpdates
+};

--- a/tests/shouldCheckForUpdates.test.ts
+++ b/tests/shouldCheckForUpdates.test.ts
@@ -1,0 +1,118 @@
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const electronDir = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'electron');
+const { shouldCheckForUpdates } = require(path.join(electronDir, 'shouldCheckForUpdates.cjs')) as {
+  shouldCheckForUpdates: (options: {
+    isPackaged: boolean;
+    env?: Record<string, string | undefined>;
+    updateFeedUrl?: string | null;
+  }) => { allowed: boolean; reason: string; feedUrl?: string };
+};
+
+describe('shouldCheckForUpdates', () => {
+  it('never allows update checks when unpackaged (dev)', () => {
+    const result = shouldCheckForUpdates({
+      isPackaged: false,
+      env: {
+        GOMI_AUTO_UPDATE: '1',
+        GOMI_UPDATE_FEED_URL: 'https://updates.example.com/gomi'
+      }
+    });
+
+    expect(result).toEqual({
+      allowed: false,
+      reason: 'not-packaged'
+    });
+  });
+
+  it('defaults packaged builds to no network check (flag off)', () => {
+    expect(
+      shouldCheckForUpdates({
+        isPackaged: true,
+        env: {}
+      })
+    ).toEqual({
+      allowed: false,
+      reason: 'flag-disabled'
+    });
+
+    expect(
+      shouldCheckForUpdates({
+        isPackaged: true,
+        env: {
+          GOMI_AUTO_UPDATE: '0',
+          GOMI_UPDATE_FEED_URL: 'https://updates.example.com/gomi'
+        }
+      }).allowed
+    ).toBe(false);
+  });
+
+  it('requires both opt-in flag and an HTTPS feed URL', () => {
+    expect(
+      shouldCheckForUpdates({
+        isPackaged: true,
+        env: { GOMI_AUTO_UPDATE: '1' }
+      })
+    ).toEqual({
+      allowed: false,
+      reason: 'missing-feed-url'
+    });
+
+    expect(
+      shouldCheckForUpdates({
+        isPackaged: true,
+        env: {
+          GOMI_AUTO_UPDATE: 'true',
+          GOMI_UPDATE_FEED_URL: 'http://insecure.example.com/feed'
+        }
+      })
+    ).toEqual({
+      allowed: false,
+      reason: 'feed-url-not-https'
+    });
+
+    expect(
+      shouldCheckForUpdates({
+        isPackaged: true,
+        env: {
+          GOMI_AUTO_UPDATE: 'yes',
+          GOMI_UPDATE_FEED_URL: 'file:///tmp/updates'
+        }
+      }).reason
+    ).toBe('feed-url-not-https');
+  });
+
+  it('allows a packaged check only when flag is on and feed is https', () => {
+    const result = shouldCheckForUpdates({
+      isPackaged: true,
+      env: {
+        GOMI_AUTO_UPDATE: '1',
+        GOMI_UPDATE_FEED_URL: 'https://updates.example.com/gomi/'
+      }
+    });
+
+    expect(result).toEqual({
+      allowed: true,
+      reason: 'enabled',
+      feedUrl: 'https://updates.example.com/gomi/'
+    });
+  });
+
+  it('prefers explicit updateFeedUrl option over env', () => {
+    const result = shouldCheckForUpdates({
+      isPackaged: true,
+      env: {
+        GOMI_AUTO_UPDATE: '1',
+        GOMI_UPDATE_FEED_URL: 'https://env.example.com/feed'
+      },
+      updateFeedUrl: 'https://option.example.com/feed'
+    });
+
+    expect(result.allowed).toBe(true);
+    expect(result.feedUrl).toBe('https://option.example.com/feed');
+  });
+});


### PR DESCRIPTION
## Summary

Implements optional Electron auto-update plumbing for Gomi, **disabled by default**.

Closes #29  
Related: mergeos-bounties/mergeos#244 (prj_0127)

## What changed

| File | Change |
| --- | --- |
| `electron/shouldCheckForUpdates.cjs` | Pure policy helper (`shouldCheckForUpdates`) |
| `electron/main.cjs` | Wire packaged main process behind the policy; optional dynamic `electron-updater` |
| `tests/shouldCheckForUpdates.test.ts` | Unit tests for the policy matrix |
| `docs/windows-release.md` | Opt-in env flags + packaging/security notes |

## Acceptance criteria

- [x] Default packaged build does **not** call the network for updates
- [x] Unit test for `shouldCheckForUpdates` policy
- [x] Docs note in `windows-release.md`

## Policy matrix

| Condition | Result |
| --- | --- |
| Unpackaged / dev | no check (`not-packaged`) |
| Packaged, default env | no check (`flag-disabled`) — **no network** |
| Packaged + flag, no feed | no check (`missing-feed-url`) |
| Packaged + flag + non-HTTPS feed | rejected (`feed-url-not-https`) |
| Packaged + `GOMI_AUTO_UPDATE=1` + `GOMI_UPDATE_FEED_URL=https://…` | may call optional `electron-updater` once with `autoDownload=false` |

## Env flags

- `GOMI_AUTO_UPDATE` — `1` / `true` / `yes` to opt in (default off)
- `GOMI_UPDATE_FEED_URL` — HTTPS feed URL required when flag is on

## Security / packaging notes

- Default release artifacts never set the flag → offline for updates
- `electron-updater` is an **optional** peer (not a hard dependency); missing module → skip, no crash
- HTTPS-only feed URLs
- `autoDownload=false` so a bad feed cannot silently replace binaries

## Evidence

```
$ npx vitest run tests/shouldCheckForUpdates.test.ts tests/electronRendererEntry.test.ts
 ✓ tests/shouldCheckForUpdates.test.ts (5 tests)
 ✓ tests/electronRendererEntry.test.ts (5 tests)
 Test Files  2 passed (2)
      Tests  10 passed (10)

$ npx vitest run tests/releaseReadiness.test.ts
 ✓ tests/releaseReadiness.test.ts (5 tests)
```

## Claim

- Starred: mergeos-bounties/mergeos
- Claiming as `github:akuraposo`
- Reward: **50 MRG** after merge (admin ledger)
