### PR TITLE
feat: add optional auto-update stub wiring (#29)

### DIFF
--- a/docs/windows-release.md
+++ b/docs/windows-release.md
@@ -149,3 +149,55 @@ VS Code's Windows setup path uses Inno Setup. MSI is not the primary upstream pa
 ## Current Limitation
 
 This repository is still a Gomi product foundation and module scaffold. A full release requires validating the native workbench contribution and patch diff preview inside a real Code - OSS fork, deepening terminal scrollback and workbench log/output-channel readers beyond the current adapter hooks, and replacing all final branding assets.
+
+## Auto-Update Configuration
+
+The packaged application includes an optional auto-update mechanism that is **disabled by default** for security and user control.
+
+To enable auto-update in a packaged build, set the following environment variables when launching the application:
+
+- `GOMI_AUTO_UPDATE=true` - Master switch to enable auto-update checks.
+- `GOMI_AUTO_UPDATE_PROVIDER=github` - Update provider (currently only `github` is supported).
+- `GOMI_AUTO_UPDATE_REPO=Gomi/Gomi-IDE` - The GitHub repository in `owner/repo` format from which to fetch updates.
+- `GOMI_AUTO_UPDATE_URL=<full_url>` - For generic providers, the full URL to the update feed (optional if using GitHub).
+- `GOMI_AUTO_UPDATE_CHANNEL=latest` - The update channel to subscribe to (e.g., `latest`, `beta`, `stable`).
+
+### Example
+
+To enable auto-update checking against the official Gomi repository:
+
+```powershell
+$env:GOMI_AUTO_UPDATE = "true"
+$env:GOMI_AUTO_UPDATE_PROVIDER = "github"
+$env:GOMI_AUTO_UPDATE_REPO = "Gomi/Gomi-IDE"
+$env:GOMI_AUTO_UPDATE_CHANNEL = "latest"
+.\Gomi-IDE.exe
+```
+
+### Security Note
+
+Auto-update requires code signing certificates for production use. Without valid signatures, the update mechanism will not function for security reasons. This stub implementation safely handles the absence of `electron-updater` and defaults to no-op when the optional dependency is not installed.
+
+
+## Auto-Update Configuration (Optional)
+
+The packaged Gomi IDE can be configured to check for updates via environment variables. By default, auto-update is disabled for safety.
+
+To enable auto-update, set the following environment variables when launching the packaged executable:
+
+- `GOMI_AUTO_UPDATE=true` - Enables the auto-update check.
+- `GOMI_AUTO_UPDATE_PROVIDER` - Either `github` or `generic` (default: `github`).
+- `GOMI_AUTO_UPDATE_REPO` - For GitHub provider, the repository in `owner/repo` format (default: `Gomi/Gomi-IDE`).
+- `GOMI_AUTO_UPDATE_URL` - For generic provider, the base URL of the update feed.
+- `GOMI_AUTO_UPDATE_CHANNEL` - The channel to use (default: `latest`).
+
+Example (GitHub):
+```bash
+set GOMI_AUTO_UPDATE=true
+set GOMI_AUTO_UPDATE_PROVIDER=github
+set GOMI_AUTO_UPDATE_REPO=MyOrg/MyApp
+Gomi-IDE.exe
+```
+
+Note: Auto-update requires the application to be code-signed. Unsigned packages will not be able to use auto-update due to Electron security restrictions.
+

--- a/electron/autoUpdater.js
+++ b/electron/autoUpdater.js
@@ -1,0 +1,88 @@
+/**
+ * Electron auto-update stub (issue #29).
+ * Wires electron-updater with feature flag (off by default).
+ * This is a stub — full implementation requires signing certs.
+ *
+ * Note: do NOT `import type` from `electron-updater` — the package is optional
+ * and not always installed in CI typecheck. Use a minimal local interface.
+ */
+
+/**
+ * @typedef {Object} AppUpdater
+ * @property {boolean} autoDownload
+ * @property {boolean} autoInstallOnAppQuit
+ * @property {string} [channel]
+ * @property {function(Object): void} setFeedURL
+ * @property {function(): Promise<unknown>} [checkForUpdates]
+ */
+
+/**
+ * @typedef {Object} AutoUpdateConfig
+ * @property {boolean} enabled
+ * @property {"github"|"generic"} provider
+ * @property {string} [repo]
+ * @property {string} [url]
+ * @property {string} [channel]
+ */
+
+/**
+ * Check if electron-updater is installed.
+ * @returns {boolean}
+ */
+function isAutoUpdateAvailable() {
+  try {
+    require.resolve("electron-updater");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Create an auto-updater instance based on the configuration.
+ * @param {AutoUpdateConfig} config
+ * @returns {AppUpdater|null}
+ */
+function createAutoUpdaterStub(config) {
+  if (!config.enabled) return null;
+
+  try {
+    // Dynamic require — electron-updater is an optional dependency
+    // eslint-disable-next-line @typescript-eslint/no-var-requires, @typescript-eslint/no-require-imports
+    const { autoUpdater } = require("electron-updater");
+
+    autoUpdater.autoDownload = false;
+    autoUpdater.autoInstallOnAppQuit = true;
+
+    if (config.provider === "github" && config.repo) {
+      // Expect repo in format "owner/repo"
+      const [owner, repo] = config.repo.split('/');
+      if (owner && repo) {
+        autoUpdater.setFeedURL({ owner, repo });
+      }
+    } else if (config.provider === "generic" && config.url) {
+      autoUpdater.setFeedURL(config.url);
+    }
+
+    if (config.channel) {
+      autoUpdater.channel = config.channel;
+    }
+
+    return autoUpdater;
+  } catch (err) {
+    // electron-updater is not installed
+    console.error("electron-updater is not installed. Skipping auto-updater setup.");
+    return null;
+  }
+}
+
+/**
+ * Determine if we should check for updates based on config and availability.
+ * @param {AutoUpdateConfig} config
+ * @returns {boolean}
+ */
+function shouldCheckForUpdates(config) {
+  return config.enabled && isAutoUpdateAvailable();
+}
+
+module.exports = { createAutoUpdaterStub, isAutoUpdateAvailable, shouldCheckForUpdates };

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -1,6 +1,7 @@
 const { app, BrowserWindow, shell, Menu } = require('electron');
 const path = require('node:path');
 const { resolveRendererEntry } = require('./resolveRendererEntry.cjs');
+const { createAutoUpdaterStub, shouldCheckForUpdates } = require('./autoUpdater.js');
 
 const isDev = !app.isPackaged;
 const rendererEntry = path.join(__dirname, '..', 'dist', 'index.html');
@@ -38,7 +39,7 @@ function createWindow() {
   }
 
   window.webContents.setWindowOpenHandler(({ url }) => {
-    if (/^https?:\/\//i.test(url)) {
+    if (/^https?:\\/\\//i.test(url)) {
       void shell.openExternal(url);
     }
 
@@ -48,7 +49,7 @@ function createWindow() {
   window.webContents.on('will-navigate', (event, url) => {
     const allowDevServer =
       entry.kind === 'url' &&
-      (url === entry.target || url.startsWith(entry.target.replace(/\/$/, '') + '/'));
+      (url === entry.target || url.startsWith(entry.target.replace(/\\/$/, '') + '/'));
 
     if (allowDevServer) {
       return;
@@ -57,7 +58,7 @@ function createWindow() {
     if (!url.startsWith('file://')) {
       event.preventDefault();
 
-      if (/^https?:\/\//i.test(url)) {
+      if (/^https?:\\/\\//i.test(url)) {
         void shell.openExternal(url);
       }
     }
@@ -70,6 +71,29 @@ app.whenReady().then(() => {
   }
 
   createWindow();
+
+  // Setup auto-update stub (optional, off by default)
+  if (!isDev) {
+    const autoUpdateEnabled = process.env.GOMI_AUTO_UPDATE === 'true';
+    const autoUpdateProvider = process.env.GOMI_AUTO_UPDATE_PROVIDER || 'github';
+    const autoUpdateRepo = process.env.GOMI_AUTO_UPDATE_REPO || 'Gomi/Gomi-IDE'; // default
+    const autoUpdateUrl = process.env.GOMI_AUTO_UPDATE_URL;
+    const autoUpdateChannel = process.env.GOMI_AUTO_UPDATE_CHANNEL || 'latest';
+
+    const config = {
+      enabled: autoUpdateEnabled,
+      provider: autoUpdateProvider,
+      repo: autoUpdateRepo,
+      url: autoUpdateUrl,
+      channel: autoUpdateChannel
+    };
+
+    const updater = createAutoUpdaterStub(config);
+    if (updater && shouldCheckForUpdates(config)) {
+      // In a real implementation would call updater.checkForUpdates();
+      console.log('Auto-update stub initialized (checks disabled by default for safety)');
+    }
+  }
 
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {


### PR DESCRIPTION
Adds optional auto-update stub wiring for electron-updater (off by default).\n\n- Adds electron/autoUpdater.js with createAutoUpdaterStub and safety checks\n- Updates electron/main.cjs to conditionally initialize auto-update based on env vars\n- Updates docs/windows-release.md with auto-update configuration guidance\n- Feature flag default off; requires GOMI_AUTO_UPDATE=true to enable\n\nCloses #29