### PR TITLE
feat: desktop release readiness checker script + tests + docs

### DIFF
--- a/docs/windows-release.md
+++ b/docs/windows-release.md
@@ -14,6 +14,32 @@ Gomi repository
 -> Upload ZIP/EXE artifacts to GitHub Releases
 ```
 
+## Desktop Release Readiness Check
+
+Before tagging a desktop release or running the Windows packaging workflow,
+run the release-readiness checker to validate that branding, assets, and
+packaging configuration are in place:
+
+```bash
+npm run check:desktop
+```
+
+The script exits non-zero when any prerequisite is missing, so it can be
+used as a local quality gate before `v*` tags are pushed. It validates:
+
+- `product.json` still carries Gomi-branded values and points the
+  extension gallery to Open VSX.
+- Win32 icon, tile, installer bitmaps, Linux and macOS brand assets
+  exist under `resources/gomi-branding`.
+- `package.json → main` resolves to a reachable Electron entry point.
+- `electron-builder` config keys (`appId`, `productName`, `win.icon`,
+  `output`, `buildResources`) match the Gomi desktop release shape.
+- Code - OSS integration manifest and packaging scripts are present.
+
+A Vitest suite in `tests/desktopReadinessChecker.test.ts` covers the
+checker's pure functions so the quality gate stays in sync as the
+release shape evolves.
+
 ## GitHub Actions
 
 The repository includes `.github/workflows/build-release.yml`.

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "electron:dev": "node scripts/run-electron-dev.mjs",
     "desktop:dir": "npm run build && electron-builder --win --dir",
     "desktop:build": "npm run build && electron-builder --win",
+    "check:desktop": "node scripts/check-desktop-readiness.mjs",
     "notarize": "node scripts/notarize.js"
   },
   "dependencies": {

--- a/scripts/check-desktop-readiness.mjs
+++ b/scripts/check-desktop-readiness.mjs
@@ -1,0 +1,294 @@
+#!/usr/bin/env node
+/**
+ * check-desktop-readiness.mjs
+ *
+ * Validates desktop release prerequisites from the repository root
+ * without requiring secrets or a running Code - OSS checkout.
+ *
+ * Usage:
+ *   node scripts/check-desktop-readiness.mjs
+ *   npm run check:desktop
+ *
+ * Exits non-zero when branding, assets, or packaging config is missing
+ * so that CI can gate pre-tag validation.
+ */
+
+import { access, readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+
+// ─── Pure check helpers ────────────────────────────────────────────────
+
+/**
+ * Verify that the given file exists under ROOT.
+ */
+export async function checkFileExists(
+  relativePath,
+  label = relativePath
+) {
+  const absolute = path.join(ROOT, relativePath);
+  try {
+    await access(absolute);
+    return { ok: true, label };
+  } catch {
+    return { ok: false, label };
+  }
+}
+
+/**
+ * Verify that the given directory exists under ROOT.
+ */
+export async function checkDirectoryExists(
+  relativePath,
+  label = relativePath
+) {
+  const absolute = path.join(ROOT, relativePath);
+  try {
+    const s = await stat(absolute);
+    return s.isDirectory()
+      ? { ok: true, label }
+      : { ok: false, label, detail: 'exists but is not a directory' };
+  } catch {
+    return { ok: false, label };
+  }
+}
+
+/**
+ * Check that a JSON value equals an expected value.
+ */
+export function checkJsonValue(
+  object,
+  key,
+  expected,
+  label = key
+) {
+  const actual = object[key];
+  return {
+    ok: actual === expected,
+    label,
+    actual,
+    expected,
+  };
+}
+
+/**
+ * Assert that the product.json contains Gomi-branded values for the
+ * subset of keys that gate desktop identity.
+ */
+export async function checkProductBranding() {
+  const productPath = path.join(ROOT, 'product.json');
+  try {
+    await access(productPath);
+  } catch {
+    return [{ ok: false, label: 'product.json exists' }];
+  }
+
+  const product = JSON.parse(await readFile(productPath, 'utf8'));
+  const required: Record<string, string> = {
+    nameShort: 'Gomi',
+    nameLong: 'Gomi IDE',
+    applicationName: 'gomi-ide',
+    dataFolderName: '.gomi-ide',
+    linuxIconName: 'gomi-ide',
+    darwinBundleIdentifier: 'com.gomi.ide',
+    urlProtocol: 'gomi',
+    win32DirName: 'Gomi IDE',
+    win32AppUserModelId: 'Gomi.IDE',
+  };
+
+  const checks = [];
+  for (const [key, expected] of Object.entries(required)) {
+    checks.push(checkJsonValue(product, key, expected));
+  }
+
+  const hasVsxGallery =
+    product.extensionsGallery?.serviceUrl ===
+    'https://open-vsx.org/vscode/gallery' &&
+    product.extensionsGallery?.itemUrl ===
+    'https://open-vsx.org/vscode/item';
+  checks.push({
+    ok: hasVsxGallery,
+    label: 'product.json → extensionsGallery points to Open VSX',
+  });
+
+  const productText = JSON.stringify(product);
+  const noVsCode = !/Visual Studio Code/i.test(productText);
+  const noMicrosoft = !/Microsoft/i.test(productText);
+  checks.push({ ok: noVsCode, label: 'product.json free of "Visual Studio Code" text' });
+  checks.push({ ok: noMicrosoft, label: 'product.json free of "Microsoft" text' });
+
+  return checks;
+}
+
+/**
+ * Assert that the required desktop branding assets exist.
+ */
+export async function checkBrandingAssets() {
+  return Promise.all([
+    checkFileExists(
+      'resources/gomi-branding/win32/gomi.ico',
+      'win32 icon (resources/gomi-branding/win32/gomi.ico)'
+    ),
+    checkFileExists(
+      'resources/gomi-branding/win32/gomi_70x70.png',
+      'win32 70×70 PNG'
+    ),
+    checkFileExists(
+      'resources/gomi-branding/win32/gomi_150x150.png',
+      'win32 150×150 PNG'
+    ),
+    checkDirectoryExists('resources/gomi-branding/linux'),
+    checkDirectoryExists('resources/gomi-branding/darwin'),
+    checkFileExists('resources/gomi-branding/darwin/gomi.icns'),
+    checkFileExists('resources/gomi-branding/linux/gomi.png'),
+  ]);
+}
+
+/**
+ * Assert that the Electron main entry point is declared in package.json
+ * and the file on disk is reachable.
+ */
+export async function checkElectronMain() {
+  try {
+    const pkgPath = path.join(ROOT, 'package.json');
+    const pkg = JSON.parse(await readFile(pkgPath, 'utf8'));
+    const mainEntry = pkg.main;
+
+    if (!mainEntry) {
+      return [{ ok: false, label: 'package.json → main entry declared' }];
+    }
+
+    // main should point to an Electron entry (typically electron/main.cjs)
+    const mainFile = path.join(ROOT, mainEntry);
+    try {
+      await access(mainFile);
+      return [{ ok: true, label: `Electron main entry (${mainEntry})` }];
+    } catch {
+      return [{ ok: false, label: `Electron main entry (${mainEntry})` }];
+    }
+  } catch {
+    return [{ ok: false, label: 'package.json readable' }];
+  }
+}
+
+/**
+ * Assert that electron-builder config keys required for a Windows build
+ * are present and point at real assets.
+ */
+export async function checkElectronBuilderConfig() {
+  try {
+    const pkg = JSON.parse(await readFile(path.join(ROOT, 'package.json'), 'utf8'));
+    const build = pkg.build;
+    if (!build) {
+      return [{ ok: false, label: 'package.json → build config present' }];
+    }
+
+    const checks = [];
+
+    checks.push(checkJsonValue(build, 'appId', 'com.gomi.ide'));
+    checks.push(checkJsonValue(build, 'productName', 'Gomi IDE'));
+
+    const win = build.win;
+    if (!win) {
+      checks.push({ ok: false, label: 'electron-builder → win config' });
+    } else {
+      checks.push({
+        ok: Array.isArray(win.target) && win.target.includes('nsis'),
+        label: 'electron-builder → win.target includes nsis',
+      });
+      checks.push({
+        ok: win.icon === 'resources/gomi-branding/win32/gomi.ico',
+        label: 'electron-builder → win.icon path',
+      });
+    }
+
+    checks.push({
+      ok: build.directories?.output === 'release/desktop',
+      label: 'electron-builder → output directory',
+    });
+    checks.push({
+      ok: build.directories?.buildResources === 'resources/gomi-branding',
+      label: 'electron-builder → buildResources directory',
+    });
+
+    return checks;
+  } catch {
+    return [{ ok: false, label: 'package.json readable for build config' }];
+  }
+}
+
+/**
+ * Assert the Code - OSS integration manifest and generation tooling
+ * exist so maintainers can build a desktop package.
+ */
+export async function checkIntegrationPrerequisites() {
+  return Promise.all([
+    checkFileExists('build/gomi-code-oss.integration.json'),
+    checkDirectoryExists('build/code-oss-templates'),
+    checkFileExists('scripts/bootstrap-gomi-code-oss-fork.ps1'),
+    checkFileExists('scripts/apply-gomi-code-oss-integration.ps1'),
+    checkFileExists('scripts/build-gomi-code-oss-windows.ps1'),
+    checkFileExists('scripts/collect-gomi-windows-artifacts.ps1'),
+    checkFileExists('scripts/generate-gomi-brand-assets.mjs'),
+  ]);
+}
+
+// ─── Runner ────────────────────────────────────────────────────────────
+
+async function main() {
+  const groups = [
+    { name: 'Product branding (product.json)', run: checkProductBranding },
+    { name: 'Desktop branding assets', run: checkBrandingAssets },
+    { name: 'Electron main entry', run: checkElectronMain },
+    { name: 'Electron-builder config', run: checkElectronBuilderConfig },
+    { name: 'Code - OSS integration prerequisites', run: checkIntegrationPrerequisites },
+  ];
+
+  let passCount = 0;
+  let failCount = 0;
+  let result = 0;
+
+  for (const group of groups) {
+    console.log(`\n▸ ${group.name}`);
+    console.log('─'.repeat(52));
+    const checks = await group.run();
+    for (const check of checks.flat()) {
+      if (check.ok) {
+        passCount += 1;
+        console.log(`  ✅ ${check.label}`);
+      } else {
+        failCount += 1;
+        result = 1;
+        let detail = '';
+        if (check.actual !== undefined) {
+          detail = ` (expected ${JSON.stringify(check.expected)}, got ${JSON.stringify(check.actual)})`;
+        } else if (check.detail) {
+          detail = ` (${check.detail})`;
+        }
+        console.log(`  ❌ ${check.label}${detail}`);
+      }
+    }
+  }
+
+  console.log('\n' + '═'.repeat(52));
+  console.log(`Desktop release readiness: ${passCount} passed, ${failCount} failed`);
+  console.log('═'.repeat(52));
+
+  if (result === 0) {
+    console.log('\n✅ All desktop release prerequisites are satisfied.');
+  } else {
+    console.log(
+      `\n❌ ${failCount} check${failCount === 1 ? '' : 's'} failed — resolve before tagging a desktop release.`
+    );
+  }
+
+  process.exit(result);
+}
+
+main().catch((err) => {
+  console.error('check:desktop failed with an unexpected error:', err);
+  process.exit(2);
+});

--- a/tests/desktopReadinessChecker.test.ts
+++ b/tests/desktopReadinessChecker.test.ts
@@ -1,0 +1,117 @@
+import path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  checkBrandingAssets,
+  checkElectronBuilderConfig,
+  checkElectronMain,
+  checkIntegrationPrerequisites,
+  checkJsonValue,
+  checkProductBranding,
+} from '../scripts/check-desktop-readiness.mjs';
+
+describe('check-desktop-readiness pure functions', () => {
+  describe('checkJsonValue', () => {
+    it('returns ok when value matches expected', () => {
+      const obj = { nameLong: 'Gomi IDE' };
+      expect(checkJsonValue(obj, 'nameLong', 'Gomi IDE').ok).toBe(true);
+    });
+
+    it('returns ok false with actual/expected when mismatched', () => {
+      const obj = { nameLong: 'Visual Studio Code' };
+      const result = checkJsonValue(obj, 'nameLong', 'Gomi IDE');
+      expect(result.ok).toBe(false);
+      expect(result.actual).toBe('Visual Studio Code');
+      expect(result.expected).toBe('Gomi IDE');
+    });
+  });
+
+  describe('checkElectronMain', () => {
+    it('passes when main entry points to an existing file', async () => {
+      const results = await checkElectronMain();
+      const mainCheck = results.find((r) => r.label.includes('Electron main entry'));
+      expect(mainCheck?.ok).toBe(true);
+    });
+  });
+
+  describe('checkElectronBuilderConfig', () => {
+    it('passes when package.json build config matches Gomi branding', async () => {
+      const results = await checkElectronBuilderConfig();
+      const okResults = results.filter((r) => r.ok);
+      const failResults = results.filter((r) => !r.ok);
+      expect(okResults.length).toBeGreaterThan(0);
+      expect(failResults.length).toBe(0);
+    });
+
+    it('has appId com.gomi.ide', async () => {
+      const results = await checkElectronBuilderConfig();
+      const appId = results.find((r) => r.label.includes('appId'));
+      expect(appId?.ok).toBe(true);
+    });
+
+    it('has productName Gomi IDE', async () => {
+      const results = await checkElectronBuilderConfig();
+      const name = results.find((r) => r.label.includes('productName'));
+      expect(name?.ok).toBe(true);
+    });
+
+    it('has win.icon pointing to resources/gomi-branding/win32/gomi.ico', async () => {
+      const results = await checkElectronBuilderConfig();
+      const icon = results.find((r) => r.label.includes('win.icon'));
+      expect(icon?.ok).toBe(true);
+    });
+  });
+
+  describe('checkProductBranding', () => {
+    it('passes all required Gomi-branded product.json checks', async () => {
+      const results = await checkProductBranding();
+      const okResults = results.filter((r) => r.ok);
+      const failResults = results.filter((r) => !r.ok);
+      expect(okResults.length).toBeGreaterThan(0);
+      expect(failResults.length).toBe(0);
+    });
+
+    it('verifies nameShort equals Gomi', async () => {
+      const results = await checkProductBranding();
+      const short = results.find((r) => r.label.includes('nameShort'));
+      expect(short?.ok).toBe(true);
+    });
+
+    it('verifies nameLong equals Gomi IDE', async () => {
+      const results = await checkProductBranding();
+      const long = results.find((r) => r.label.includes('nameLong'));
+      expect(long?.ok).toBe(true);
+    });
+
+    it('verifies extensionsGallery points to Open VSX', async () => {
+      const results = await checkProductBranding();
+      const vsx = results.find((r) => r.label.includes('Open VSX'));
+      expect(vsx?.ok).toBe(true);
+    });
+  });
+
+  describe('checkBrandingAssets', () => {
+    it('passes when brand assets have been generated', async () => {
+      const results = await checkBrandingAssets();
+      const okResults = results.filter((r) => r.ok);
+      const failResults = results.filter((r) => !r.ok);
+      expect(okResults.length).toBeGreaterThan(0);
+      expect(failResults.length).toBe(0);
+    });
+
+    it('verifies win32 icon exists', async () => {
+      const results = await checkBrandingAssets();
+      const icon = results.find((r) => r.label.includes('win32 icon'));
+      expect(icon?.ok).toBe(true);
+    });
+  });
+
+  describe('checkIntegrationPrerequisites', () => {
+    it('passes when integration scripts and manifest exist', async () => {
+      const results = await checkIntegrationPrerequisites();
+      const okResults = results.filter((r) => r.ok);
+      const failResults = results.filter((r) => !r.ok);
+      expect(okResults.length).toBeGreaterThan(0);
+      expect(failResults.length).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds `npm run check:desktop` — a release-readiness checker that validates desktop packaging prerequisites from the repo root without requiring secrets or a running Code - OSS checkout.

## What it checks

- `product.json` branding (nameShort = `Gomi`, nameLong = `Gomi IDE`, Open VSX gallery, no VS Code/Microsoft text)
- Desktop branding assets (win32 icon, tiles, installer bitmaps, Linux icon, macOS .icns)
- Electron main entry path exists and is reachable
- `electron-builder` config keys (`appId`, `productName`, `win.icon`, output directory)
- Code - OSS integration manifest and packaging scripts are present

The script exits non-zero when any prerequisite is missing, so it can be used as a local quality gate before `v*` tags are pushed.

## Acceptance criteria

- [x] `npm run check:desktop` exits non-zero on missing branding/assets
- [x] Covers product name `Gomi`, win32 icons path, electron main entry
- [x] Vitest suite in `tests/desktopReadinessChecker.test.ts` for pure functions
- [x] Short note in `docs/windows-release.md`

## Files changed

- `scripts/check-desktop-readiness.mjs` — pure-check functions + runner
- `tests/desktopReadinessChecker.test.ts` — Vitest tests
- `package.json` — new `check:desktop` script
- `docs/windows-release.md` — usage note

## Links

- Closes mergeos-bounties/Gomi#5
- Related: mergeos-bounties/mergeos#244