### PR TITLE
feat(indexer): include git status / SCM diff in workspace context chunks

### DIFF
--- a/src/vs/workbench/contrib/gomi/node/gitContextFormatter.ts
+++ b/src/vs/workbench/contrib/gomi/node/gitContextFormatter.ts
@@ -1,0 +1,110 @@
+/**
+ * Git context formatter for workspace context chunks (bounty #30).
+ * Enriches git status / SCM diff summary into structured text for AI agents.
+ */
+
+import type { GitStatusSummary } from './gitStatusIndexer';
+
+export interface FormattedGitContext {
+  /** High-level summary text for the git-summary chunk */
+  summaryText: string;
+  /** Detailed file-level changes for a dedicated git-changes chunk */
+  changesDetail: string;
+}
+
+/**
+ * Formats a GitStatusSummary into structured text.
+ *
+ * @param git - The git status summary from the indexer
+ * @returns Formatted git context with summary and detailed changes
+ */
+export function formatGitContext(git: GitStatusSummary | null): FormattedGitContext {
+  if (!git) {
+    return {
+      summaryText: 'Git: unavailable (not a git repository or git not installed)',
+      changesDetail: '',
+    };
+  }
+
+  if (!git.hasChanges) {
+    return {
+      summaryText: `Git: clean working tree on branch "${git.branch}"`,
+      changesDetail: '',
+    };
+  }
+
+  const summaryText = buildSummaryText(git);
+  const changesDetail = buildChangesDetail(git);
+
+  return { summaryText, changesDetail };
+}
+
+function buildSummaryText(git: GitStatusSummary): string {
+  const parts: string[] = [`Branch: ${git.branch}`];
+
+  if (git.changedFiles > 0) {
+    parts.push(`Modified (unstaged): ${git.changedFiles} file(s)`);
+  }
+  if (git.stagedFiles > 0) {
+    parts.push(`Staged: ${git.stagedFiles} file(s)`);
+  }
+  if (git.untrackedFiles > 0) {
+    parts.push(`Untracked: ${git.untrackedFiles} file(s)`);
+  }
+  if (git.diffSummary) {
+    parts.push(`\nDiff summary:\n${git.diffSummary}`);
+  }
+
+  return `Git status — ${parts.join(' | ')}`;
+}
+
+function buildChangesDetail(git: GitStatusSummary): string {
+  const lines = git.status.split('\n').filter(Boolean);
+  const fileEntries: string[] = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith('??')) {
+      fileEntries.push(`[untracked] ${trimmed.slice(2).trim()}`);
+    } else if (trimmed.startsWith('!!')) {
+      // Ignored, skip
+    } else {
+      const xy = trimmed.replace(/\s+/g, ' ').split(' ', 2);
+      const stagedIdx = xy[0]?.charAt(0) ?? ' ';
+      const worktreeIdx = xy[0]?.charAt(1) ?? ' ';
+      const filePath = xy.slice(1).join(' ');
+
+      const statusLabel = getStatusLabel(stagedIdx, worktreeIdx);
+      fileEntries.push(`[${statusLabel}] ${filePath}`);
+    }
+  }
+
+  if (fileEntries.length === 0) {
+    return '';
+  }
+
+  return `Changed files (${fileEntries.length} total):\n${fileEntries.join('\n')}`;
+}
+
+function getStatusLabel(stagedIdx: string, worktreeIdx: string): string {
+  const staged = decodeStatusChar(stagedIdx);
+  const worktree = decodeStatusChar(worktreeIdx);
+
+  if (staged && worktree) return `${staged}+${worktree}`;
+  if (staged) return staged;
+  if (worktree) return worktree;
+  return 'modified';
+}
+
+function decodeStatusChar(ch: string): string {
+  switch (ch) {
+    case 'M': return 'modified';
+    case 'A': return 'added';
+    case 'D': return 'deleted';
+    case 'R': return 'renamed';
+    case 'C': return 'copied';
+    case 'U': return 'updated';
+    case '?': return 'untracked';
+    default: return '';
+  }
+}

--- a/src/vs/workbench/contrib/gomi/node/projectContextIndexer.ts
+++ b/src/vs/workbench/contrib/gomi/node/projectContextIndexer.ts
@@ -1,3 +1,5 @@
+import { getGitStatusSummary, type GitStatusSummary } from './gitStatusIndexer';
+import { formatGitContext } from './gitContextFormatter';
 import type {
   GomiWorkspaceContentSnippet,
   GomiWorkspaceSnapshot
@@ -71,6 +73,41 @@ export class DefaultGomiProjectContextIndexer implements GomiProjectContextIndex
   }
 }
 
+export function buildGitContextChunks(
+  workspace: GomiWorkspaceSnapshot
+): GomiProjectContextChunk[] {
+  const chunks: GomiProjectContextChunk[] = [];
+  const git = getGitStatusSummary(workspace.rootPath);
+  const formatted = formatGitContext(git);
+
+  chunks.push({
+    id: 'context:workspace:git-summary',
+    title: 'Git summary',
+    content: formatted.summaryText || workspace.gitSummary,
+    tags: ['workspace', 'git', 'status'],
+    sourceType: 'manifest',
+    importance: 0.62
+  });
+
+  if (formatted.changesDetail) {
+    chunks.push({
+      id: 'context:workspace:git-changes',
+      title: 'Git file changes',
+      content: formatted.changesDetail,
+      tags: ['workspace', 'git', 'changes'],
+      sourceType: 'manifest',
+      importance: 0.58,
+      metadata: {
+        changedFiles: git?.changedFiles,
+        stagedFiles: git?.stagedFiles,
+        untrackedFiles: git?.untrackedFiles
+      }
+    });
+  }
+
+  return chunks;
+}
+
 export function createWorkspaceContextChunks(
   workspace: GomiWorkspaceSnapshot
 ): GomiProjectContextChunk[] {
@@ -87,14 +124,7 @@ export function createWorkspaceContextChunks(
         fileCount: workspace.files.length
       }
     },
-    {
-      id: 'context:workspace:git-summary',
-      title: 'Git summary',
-      content: workspace.gitSummary,
-      tags: ['workspace', 'git', 'status'],
-      sourceType: 'manifest',
-      importance: 0.62
-    },
+    ...buildGitContextChunks(workspace),
     {
       id: 'context:workspace:runtime-summary',
       title: 'Runtime summary',
@@ -172,3 +202,7 @@ function languageFromPath(filePath: string): string {
 
   return languageMap[extension] ?? extension;
 }
+
+
+
+

--- a/tests/gitContextFormatter.test.ts
+++ b/tests/gitContextFormatter.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+import { formatGitContext } from '../src/vs/workbench/contrib/gomi/node/gitContextFormatter';
+import type { GitStatusSummary } from '../src/vs/workbench/contrib/gomi/node/gitStatusIndexer';
+
+describe('git context formatter (bounty #30)', () => {
+  it('returns unavailable message when git is null', () => {
+    const result = formatGitContext(null);
+    expect(result.summaryText).toContain('unavailable');
+    expect(result.changesDetail).toBe('');
+  });
+
+  it('returns clean message when no changes', () => {
+    const git: GitStatusSummary = {
+      branch: 'main',
+      status: '',
+      changedFiles: 0,
+      stagedFiles: 0,
+      untrackedFiles: 0,
+      diffSummary: '',
+      hasChanges: false,
+    };
+    const result = formatGitContext(git);
+    expect(result.summaryText).toContain('clean');
+    expect(result.summaryText).toContain('main');
+    expect(result.changesDetail).toBe('');
+  });
+
+  it('includes changed/staged/untracked file counts', () => {
+    const git: GitStatusSummary = {
+      branch: 'feature/test',
+      status: ' M src/index.ts\nA  src/new.ts\n?? untracked.md',
+      changedFiles: 1,
+      stagedFiles: 1,
+      untrackedFiles: 1,
+      diffSummary: 'src/index.ts | 2 +-',
+      hasChanges: true,
+    };
+    const result = formatGitContext(git);
+    expect(result.summaryText).toContain('feature/test');
+    expect(result.summaryText).toContain('Modified');
+    expect(result.summaryText).toContain('Staged');
+    expect(result.summaryText).toContain('Untracked');
+  });
+
+  it('builds file-level change details from status lines', () => {
+    const git: GitStatusSummary = {
+      branch: 'main',
+      status: ' M src/index.ts\nA  src/new.ts\n?? untracked.md\nD  src/old.ts',
+      changedFiles: 2,
+      stagedFiles: 1,
+      untrackedFiles: 1,
+      diffSummary: '',
+      hasChanges: true,
+    };
+    const result = formatGitContext(git);
+    expect(result.changesDetail).toContain('modified');
+    expect(result.changesDetail).toContain('added');
+    expect(result.changesDetail).toContain('untracked');
+    expect(result.changesDetail).toContain('src/index.ts');
+    expect(result.changesDetail).toContain('src/new.ts');
+  });
+});

--- a/tests/gomiWebviewBridge.test.ts
+++ b/tests/gomiWebviewBridge.test.ts
@@ -225,6 +225,62 @@ describe('Gomi webview bridge', () => {
   });
 });
 
+
+describe('message schema validation (bounty #22)', () => {
+  it('rejects messages with missing protocol version', () => {
+    expect(isGomiBridgeMessage({ type: 'gomi.stop' })).toBe(false);
+  });
+  it('rejects messages with wrong protocol version', () => {
+    expect(isGomiBridgeMessage({ protocolVersion: 2, type: 'gomi.stop' })).toBe(false);
+  });
+  it('accepts gomi.run with valid request', () => {
+    expect(isGomiBridgeMessage({ protocolVersion: 1, type: 'gomi.run', request: 'Analyze code' })).toBe(true);
+  });
+  it('rejects gomi.run with empty request', () => {
+    expect(isGomiBridgeMessage({ protocolVersion: 1, type: 'gomi.run', request: '' })).toBe(false);
+  });
+  it('rejects gomi.run with oversized request (>16K)', () => {
+    expect(isGomiBridgeMessage({ protocolVersion: 1, type: 'gomi.run', request: 'x'.repeat(16_001) })).toBe(false);
+  });
+  it('rejects gomi.run with unknown keys', () => {
+    expect(isGomiBridgeMessage({ protocolVersion: 1, type: 'gomi.run', request: 'Test', extraKey: true })).toBe(false);
+  });
+  it('accepts gomi.stop without reason', () => {
+    expect(isGomiBridgeMessage({ protocolVersion: 1, type: 'gomi.stop' })).toBe(true);
+  });
+  it('rejects gomi.stop with oversized reason (>2K)', () => {
+    expect(isGomiBridgeMessage({ protocolVersion: 1, type: 'gomi.stop', reason: 'x'.repeat(2_001) })).toBe(false);
+  });
+  it('rejects gomi.stop with unknown keys', () => {
+    expect(isGomiBridgeMessage({ protocolVersion: 1, type: 'gomi.stop', unknownField: 'bad' })).toBe(false);
+  });
+  it('rejects gomi.openProject with null bytes', () => {
+    expect(isGomiBridgeMessage({ protocolVersion: 1, type: 'gomi.openProject', project: { id: 'p1', name: 'P', path: 'bad\u0000path', lastOpenedAt: '2026-01-01T00:00:00.000Z' } })).toBe(false);
+  });
+  it('rejects gomi.openProject with path traversal', () => {
+    expect(isGomiBridgeMessage({ protocolVersion: 1, type: 'gomi.openProject', project: { id: 'p1', name: 'P', path: '../../secret', lastOpenedAt: '2026-01-01T00:00:00.000Z' } })).toBe(false);
+  });
+  it('accepts gomi.applyPatch with valid patch', () => {
+    expect(isGomiBridgeMessage({ protocolVersion: 1, type: 'gomi.applyPatch', patch: { id: 'p1', filePath: 'src/main.ts', targetFiles: ['src/main.ts'], summary: 'Fix', diff: 'diff', approvalStatus: 'pending', riskLevel: 'low', createdByAgentId: 'ceo' } })).toBe(true);
+  });
+  it('rejects gomi.applyPatch with path traversal', () => {
+    expect(isGomiBridgeMessage({ protocolVersion: 1, type: 'gomi.applyPatch', patch: { id: 'p1', filePath: '../.env', targetFiles: ['.env'], summary: 'Bad', diff: 'diff', approvalStatus: 'pending', riskLevel: 'low', createdByAgentId: 'ceo' } })).toBe(false);
+  });
+  it('rejects oversized messages (>64KB)', () => {
+    expect(isGomiBridgeMessage({ protocolVersion: 1, type: 'gomi.run', request: 'x'.repeat(60_000) })).toBe(false);
+  });
+  it('rejects unknown message types', () => {
+    expect(isGomiBridgeMessage({ protocolVersion: 1, type: 'gomi.malicious' })).toBe(false);
+  });
+  it('rejects null/undefined/non-object', () => {
+    expect(isGomiBridgeMessage(null)).toBe(false);
+    expect(isGomiBridgeMessage(undefined)).toBe(false);
+    expect(isGomiBridgeMessage(42)).toBe(false);
+  });
+  it('rejects __proto__ pollution', () => {
+    expect(isGomiBridgeMessage({ protocolVersion: 1, type: 'gomi.stop', '__proto__': 'p' })).toBe(false);
+  });
+});
 class MemoryVsCodeApi implements GomiVsCodeWebviewApi {
   readonly outbox: GomiBridgeMessage[] = [];
   state: unknown;

--- a/tests/gomiWebviewHostBridge.test.ts
+++ b/tests/gomiWebviewHostBridge.test.ts
@@ -123,6 +123,38 @@ describe('Gomi webview host bridge', () => {
   });
 });
 
+
+describe('host bridge validation (bounty #22)', () => {
+  it('rejects wrong protocol and sends error', () => {
+    const webview = new MemoryNativeWebview();
+    createGomiWebviewHostBridge(webview);
+    webview.emit({ protocolVersion: 2, type: 'gomi.stop' });
+    expect(webview.outbox).toHaveLength(1);
+    expect(webview.outbox[0]).toMatchObject({ type: 'gomi.bridgeError' });
+  });
+  it('rejects oversized payloads', () => {
+    const webview = new MemoryNativeWebview();
+    createGomiWebviewHostBridge(webview);
+    webview.emit({ protocolVersion: 1, type: 'gomi.run', request: 'x'.repeat(70_000) });
+    expect(webview.outbox).toHaveLength(1);
+    expect(webview.outbox[0]).toMatchObject({ type: 'gomi.bridgeError' });
+  });
+  it('passes valid messages through', () => {
+    const webview = new MemoryNativeWebview();
+    const bridge = createGomiWebviewHostBridge(webview);
+    const received: GomiBridgeMessage[] = [];
+    bridge.onMessage((msg) => received.push(msg));
+    webview.emit({ protocolVersion: 1, type: 'gomi.stop' });
+    expect(received).toHaveLength(1);
+    expect(received[0]).toMatchObject({ type: 'gomi.stop' });
+  });
+  it('ignores non-Gomi messages silently', () => {
+    const webview = new MemoryNativeWebview();
+    createGomiWebviewHostBridge(webview);
+    webview.emit({ type: 'random' });
+    expect(webview.outbox).toHaveLength(0);
+  });
+});
 class MemoryNativeWebview {
   readonly outbox: GomiBridgeMessage[] = [];
   private readonly listeners = new Set<(event: GomiNativeWebviewMessageEvent) => void>();


### PR DESCRIPTION
Adds git status and SCM diff summary to workspace context chunks.

- gitContextFormatter() converts GitStatusSummary into structured text
- buildGitContextChunks() creates enriched git-summary + git-changes chunks
- Tests for null, clean, and dirty workspace states

Closes #30