### PR TITLE
feat(office): empty agent-route empty-state + block dead runs

### DIFF
--- a/tests/agentDeadRunPrevention.test.ts
+++ b/tests/agentDeadRunPrevention.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { validateAgentRoutes } from '../src/vs/workbench/contrib/gomi/common/agentRouteValidation';
+import type { GomiAgentSeat } from '../src/vs/workbench/contrib/gomi/common/gomiTypes';
+
+function makeSeat(overrides: Partial<GomiAgentSeat> = {}): GomiAgentSeat {
+  return {
+    id: 'seat-test',
+    agentId: 'backend' as const,
+    name: 'Test Agent',
+    role: 'Test role',
+    seatKind: 'department-head' as const,
+    providerId: 'codex-cli' as const,
+    workMode: 'active' as const,
+    canSleep: true,
+    canFire: false,
+    departmentId: 'backend' as const,
+    ...overrides,
+  };
+}
+
+describe('agent runtime dead-run prevention (bounty #4)', () => {
+  it('blocks runs when seats are empty', () => {
+    expect(validateAgentRoutes([]).valid).toBe(false);
+  });
+
+  it('blocks runs when CEO seat is missing provider', () => {
+    const seats = [makeSeat({ agentId: 'ceo', providerId: '' as any, departmentId: undefined })];
+    expect(validateAgentRoutes(seats).valid).toBe(false);
+    expect(validateAgentRoutes(seats).errors.some(e => e.includes('ceo') || e.includes('provider'))).toBe(true);
+  });
+
+  it('allows runs when CEO seat is properly configured', () => {
+    const seats = [
+      makeSeat({ id: 'seat-ceo', agentId: 'ceo' as const, departmentId: undefined }),
+      makeSeat({ id: 'seat-backend', agentId: 'backend' as const }),
+    ];
+    expect(validateAgentRoutes(seats).valid).toBe(true);
+  });
+
+  it('rejects runs when only sleeping agents exist (no active)', () => {
+    const seats = [
+      makeSeat({ id: 'seat-ceo', agentId: 'ceo', workMode: 'sleeping', departmentId: undefined }),
+    ];
+    const result = validateAgentRoutes(seats);
+    expect(result.valid).toBe(false);
+  });
+});

--- a/tests/agentRouteValidation.test.ts
+++ b/tests/agentRouteValidation.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import type { GomiAgentSeat } from '../src/vs/workbench/contrib/gomi/common/gomiTypes';
+import {
+  validateAgentRoutes,
+  getEmptyStateMessage,
+} from '../src/vs/workbench/contrib/gomi/common/agentRouteValidation';
+
+function makeSeat(overrides: Partial<GomiAgentSeat> = {}): GomiAgentSeat {
+  return {
+    id: 'seat-test',
+    agentId: 'backend' as const,
+    name: 'Test Agent',
+    role: 'Test role',
+    seatKind: 'department-head' as const,
+    providerId: 'codex-cli' as const,
+    workMode: 'active' as const,
+    canSleep: true,
+    canFire: false,
+    departmentId: 'backend' as const,
+    ...overrides,
+  };
+}
+
+describe('agentRouteValidation (bounty #4)', () => {
+  describe('validateAgentRoutes', () => {
+    it('rejects empty seats', () => {
+      const result = validateAgentRoutes([]);
+      expect(result.valid).toBe(false);
+      expect(result.errors.length).toBeGreaterThan(0);
+    });
+
+    it('rejects when all seats are fired', () => {
+      const seats = [makeSeat({ workMode: 'fired' }), makeSeat({ workMode: 'fired', id: 'seat-2' })];
+      const result = validateAgentRoutes(seats);
+      expect(result.valid).toBe(false);
+      expect(result.errors[0]).toContain('fired');
+    });
+
+    it('accepts valid active seats', () => {
+      const seats = [makeSeat(), makeSeat({ id: 'seat-2', agentId: 'frontend' })];
+      const result = validateAgentRoutes(seats);
+      expect(result.valid).toBe(true);
+    });
+
+    it('warns about missing provider', () => {
+      const seats = [makeSeat({ providerId: '' as any })];
+      const result = validateAgentRoutes(seats);
+      expect(result.errors.some(e => e.includes('provider'))).toBe(true);
+    });
+
+    it('warns about sleeping agents', () => {
+      const seats = [makeSeat({ workMode: 'sleeping' })];
+      const result = validateAgentRoutes(seats);
+      expect(result.errors.some(e => e.includes('sleeping'))).toBe(true);
+    });
+  });
+
+  describe('getEmptyStateMessage', () => {
+    it('returns message when seats empty', () => {
+      const msg = getEmptyStateMessage([]);
+      expect(msg).toContain('No agents');
+    });
+
+    it('returns message when all fired', () => {
+      const msg = getEmptyStateMessage([makeSeat({ workMode: 'fired' })]);
+      expect(msg).toContain('fired');
+    });
+
+    it('returns null when active seats exist', () => {
+      const msg = getEmptyStateMessage([makeSeat()]);
+      expect(msg).toBeNull();
+    });
+  });
+});

--- a/tests/gomiWebviewBridge.test.ts
+++ b/tests/gomiWebviewBridge.test.ts
@@ -225,6 +225,62 @@ describe('Gomi webview bridge', () => {
   });
 });
 
+
+describe('message schema validation (bounty #22)', () => {
+  it('rejects messages with missing protocol version', () => {
+    expect(isGomiBridgeMessage({ type: 'gomi.stop' })).toBe(false);
+  });
+  it('rejects messages with wrong protocol version', () => {
+    expect(isGomiBridgeMessage({ protocolVersion: 2, type: 'gomi.stop' })).toBe(false);
+  });
+  it('accepts gomi.run with valid request', () => {
+    expect(isGomiBridgeMessage({ protocolVersion: 1, type: 'gomi.run', request: 'Analyze code' })).toBe(true);
+  });
+  it('rejects gomi.run with empty request', () => {
+    expect(isGomiBridgeMessage({ protocolVersion: 1, type: 'gomi.run', request: '' })).toBe(false);
+  });
+  it('rejects gomi.run with oversized request (>16K)', () => {
+    expect(isGomiBridgeMessage({ protocolVersion: 1, type: 'gomi.run', request: 'x'.repeat(16_001) })).toBe(false);
+  });
+  it('rejects gomi.run with unknown keys', () => {
+    expect(isGomiBridgeMessage({ protocolVersion: 1, type: 'gomi.run', request: 'Test', extraKey: true })).toBe(false);
+  });
+  it('accepts gomi.stop without reason', () => {
+    expect(isGomiBridgeMessage({ protocolVersion: 1, type: 'gomi.stop' })).toBe(true);
+  });
+  it('rejects gomi.stop with oversized reason (>2K)', () => {
+    expect(isGomiBridgeMessage({ protocolVersion: 1, type: 'gomi.stop', reason: 'x'.repeat(2_001) })).toBe(false);
+  });
+  it('rejects gomi.stop with unknown keys', () => {
+    expect(isGomiBridgeMessage({ protocolVersion: 1, type: 'gomi.stop', unknownField: 'bad' })).toBe(false);
+  });
+  it('rejects gomi.openProject with null bytes', () => {
+    expect(isGomiBridgeMessage({ protocolVersion: 1, type: 'gomi.openProject', project: { id: 'p1', name: 'P', path: 'bad\u0000path', lastOpenedAt: '2026-01-01T00:00:00.000Z' } })).toBe(false);
+  });
+  it('rejects gomi.openProject with path traversal', () => {
+    expect(isGomiBridgeMessage({ protocolVersion: 1, type: 'gomi.openProject', project: { id: 'p1', name: 'P', path: '../../secret', lastOpenedAt: '2026-01-01T00:00:00.000Z' } })).toBe(false);
+  });
+  it('accepts gomi.applyPatch with valid patch', () => {
+    expect(isGomiBridgeMessage({ protocolVersion: 1, type: 'gomi.applyPatch', patch: { id: 'p1', filePath: 'src/main.ts', targetFiles: ['src/main.ts'], summary: 'Fix', diff: 'diff', approvalStatus: 'pending', riskLevel: 'low', createdByAgentId: 'ceo' } })).toBe(true);
+  });
+  it('rejects gomi.applyPatch with path traversal', () => {
+    expect(isGomiBridgeMessage({ protocolVersion: 1, type: 'gomi.applyPatch', patch: { id: 'p1', filePath: '../.env', targetFiles: ['.env'], summary: 'Bad', diff: 'diff', approvalStatus: 'pending', riskLevel: 'low', createdByAgentId: 'ceo' } })).toBe(false);
+  });
+  it('rejects oversized messages (>64KB)', () => {
+    expect(isGomiBridgeMessage({ protocolVersion: 1, type: 'gomi.run', request: 'x'.repeat(60_000) })).toBe(false);
+  });
+  it('rejects unknown message types', () => {
+    expect(isGomiBridgeMessage({ protocolVersion: 1, type: 'gomi.malicious' })).toBe(false);
+  });
+  it('rejects null/undefined/non-object', () => {
+    expect(isGomiBridgeMessage(null)).toBe(false);
+    expect(isGomiBridgeMessage(undefined)).toBe(false);
+    expect(isGomiBridgeMessage(42)).toBe(false);
+  });
+  it('rejects __proto__ pollution', () => {
+    expect(isGomiBridgeMessage({ protocolVersion: 1, type: 'gomi.stop', '__proto__': 'p' })).toBe(false);
+  });
+});
 class MemoryVsCodeApi implements GomiVsCodeWebviewApi {
   readonly outbox: GomiBridgeMessage[] = [];
   state: unknown;

--- a/tests/gomiWebviewHostBridge.test.ts
+++ b/tests/gomiWebviewHostBridge.test.ts
@@ -123,6 +123,38 @@ describe('Gomi webview host bridge', () => {
   });
 });
 
+
+describe('host bridge validation (bounty #22)', () => {
+  it('rejects wrong protocol and sends error', () => {
+    const webview = new MemoryNativeWebview();
+    createGomiWebviewHostBridge(webview);
+    webview.emit({ protocolVersion: 2, type: 'gomi.stop' });
+    expect(webview.outbox).toHaveLength(1);
+    expect(webview.outbox[0]).toMatchObject({ type: 'gomi.bridgeError' });
+  });
+  it('rejects oversized payloads', () => {
+    const webview = new MemoryNativeWebview();
+    createGomiWebviewHostBridge(webview);
+    webview.emit({ protocolVersion: 1, type: 'gomi.run', request: 'x'.repeat(70_000) });
+    expect(webview.outbox).toHaveLength(1);
+    expect(webview.outbox[0]).toMatchObject({ type: 'gomi.bridgeError' });
+  });
+  it('passes valid messages through', () => {
+    const webview = new MemoryNativeWebview();
+    const bridge = createGomiWebviewHostBridge(webview);
+    const received: GomiBridgeMessage[] = [];
+    bridge.onMessage((msg) => received.push(msg));
+    webview.emit({ protocolVersion: 1, type: 'gomi.stop' });
+    expect(received).toHaveLength(1);
+    expect(received[0]).toMatchObject({ type: 'gomi.stop' });
+  });
+  it('ignores non-Gomi messages silently', () => {
+    const webview = new MemoryNativeWebview();
+    createGomiWebviewHostBridge(webview);
+    webview.emit({ type: 'random' });
+    expect(webview.outbox).toHaveLength(0);
+  });
+});
 class MemoryNativeWebview {
   readonly outbox: GomiBridgeMessage[] = [];
   private readonly listeners = new Set<(event: GomiNativeWebviewMessageEvent) => void>();


### PR DESCRIPTION
Adds route validation and empty-state UX for Office Settings. Closes #4