### PR TITLE
Add Office Settings search

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -892,6 +892,64 @@ button {
   cursor: pointer;
 }
 
+.gomi-settings-search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-height: 34px;
+  padding: 0 10px;
+  border: 1px solid #253247;
+  border-radius: 8px;
+  background: #020617;
+  color: #94a3b8;
+}
+
+.gomi-settings-search input {
+  width: 100%;
+  min-width: 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: #e2e8f0;
+  font: inherit;
+}
+
+.gomi-settings-search input::placeholder {
+  color: #64748b;
+}
+
+.gomi-settings-search:focus-within {
+  border-color: #14b8a6;
+  box-shadow: 0 0 0 1px rgba(20, 184, 166, 0.18);
+}
+
+.gomi-settings-search-summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  color: #94a3b8;
+  font-size: 11px;
+}
+
+.gomi-settings-search-chip {
+  display: inline-flex;
+  max-width: 100%;
+  padding: 2px 6px;
+  border: 1px solid #315547;
+  border-radius: 4px;
+  background: #12251f;
+  color: #99f6e4;
+}
+
+.gomi-settings-empty {
+  border: 1px dashed #334155;
+  border-radius: 8px;
+  padding: 12px;
+  color: #94a3b8;
+  text-align: center;
+}
+
 .gomi-provider-status-bar {
   display: flex;
   flex-wrap: wrap;

--- a/src/vs/workbench/contrib/gomi/browser/GomiOfficeApp.tsx
+++ b/src/vs/workbench/contrib/gomi/browser/GomiOfficeApp.tsx
@@ -122,6 +122,11 @@ import {
   exportSettingsToJson,
   importSettingsFromJson
 } from '../common/gomiOfficeSettingsExport';
+import {
+  buildSettingsSearchIndex,
+  matchesSettingsSearch,
+  searchSettings
+} from '../common/settingsSearch';
 import { resolveGomiWebviewBridgeContext } from './gomiWebviewBridge';
 import { PhaserOffice } from './PhaserOffice';
 import { formatGomiTaskStatusLabel } from './gomiTaskView';
@@ -1571,6 +1576,7 @@ function OfficeSettingsPanel({
   onHttpProviderMaxRetriesChange: (httpMaxRetries: number) => void;
   onPruneMemory: () => void;
 }) {
+  const [settingsSearchQuery, setSettingsSearchQuery] = useState('');
   const leaders = officeSettings.seats.filter((seat) => seat.seatKind !== 'employee');
   const employees = officeSettings.seats.filter((seat) => seat.seatKind === 'employee');
   const employeeDepartments = GOMI_HIRABLE_DEPARTMENT_IDS.map((departmentId) => ({
@@ -1587,6 +1593,54 @@ function OfficeSettingsPanel({
     selectedEmbeddingProvider.modelEnv,
     selectedEmbeddingProvider.apiKeyEnv
   ].filter(Boolean);
+  const settingsSearchIndex = useMemo(
+    () => buildSettingsSearchIndex(officeSettings as unknown as Record<string, unknown>),
+    [officeSettings]
+  );
+  const settingsSearchResults = useMemo(
+    () => searchSettings(settingsSearchIndex, settingsSearchQuery),
+    [settingsSearchIndex, settingsSearchQuery]
+  );
+  const settingsSearchTerms = useMemo(
+    () => settingsSearchQuery.toLowerCase().trim().split(/\s+/).filter(Boolean),
+    [settingsSearchQuery]
+  );
+  const showAppearanceSettings = matchesSettingsSearch(
+    ['Office Appearance', 'agent avatar style', officeSettings.avatarStyle, GOMI_AVATAR_STYLE_OPTIONS],
+    settingsSearchQuery
+  );
+  const showLeaderSettings = matchesSettingsSearch(
+    ['CEO And Department Heads', 'leader provider sleep wake', leaders],
+    settingsSearchQuery
+  );
+  const showEmployeeSettings = matchesSettingsSearch(
+    ['Employees', 'staffing hire fire restore department active total', employeeDepartments],
+    settingsSearchQuery
+  );
+  const showMemorySettings = matchesSettingsSearch(
+    [
+      'Shared Memory',
+      'embedding provider privacy retention broadcast threshold terminal snippets workspace context patch approval prune',
+      officeSettings.memory,
+      selectedEmbeddingProvider,
+      embeddingEnvNames,
+      memoryItems,
+      memoryPruneReport
+    ],
+    settingsSearchQuery
+  );
+  const showExecutionSettings = matchesSettingsSearch(
+    ['Execution Policy', 'workspace trust live provider CLI HTTP retries concurrent approval', officeSettings.execution],
+    settingsSearchQuery
+  );
+  const visibleSettingsGroupCount = [
+    showAppearanceSettings,
+    showLeaderSettings,
+    showEmployeeSettings,
+    showMemorySettings,
+    showExecutionSettings
+  ].filter(Boolean).length;
+  const searchPreviewResults = settingsSearchResults.slice(0, 5);
 
   return (
     <section className="gomi-settings-panel" aria-label="Office Settings">
@@ -1616,8 +1670,32 @@ function OfficeSettingsPanel({
         </label>
       </div>
 
+      <label className="gomi-settings-search" htmlFor="gomi-settings-search-input">
+        <Search size={14} />
+        <input
+          id="gomi-settings-search-input"
+          type="search"
+          value={settingsSearchQuery}
+          onChange={(event) => setSettingsSearchQuery(event.target.value)}
+          placeholder="Search settings"
+          aria-label="Search settings"
+        />
+      </label>
+
+      {settingsSearchTerms.length > 0 ? (
+        <div className="gomi-settings-search-summary" aria-live="polite">
+          <span>{visibleSettingsGroupCount} section{visibleSettingsGroupCount === 1 ? '' : 's'} matched</span>
+          {searchPreviewResults.map((result) => (
+            <mark className="gomi-settings-search-chip" key={`${result.section}-${result.key}`}>
+              {result.section}: {result.label}
+            </mark>
+          ))}
+        </div>
+      ) : undefined}
+
       <ProviderStatusBar officeSettings={officeSettings} />
 
+      {showAppearanceSettings ? (
       <div className="gomi-settings-group">
         <div className="gomi-settings-title">Office Appearance</div>
         <div className="gomi-avatar-style-controls" role="radiogroup" aria-label="Agent avatar style">
@@ -1635,7 +1713,9 @@ function OfficeSettingsPanel({
           ))}
         </div>
       </div>
+      ) : undefined}
 
+      {showLeaderSettings ? (
       <div className="gomi-settings-group">
         <div className="gomi-settings-title">CEO And Department Heads</div>
         {leaders.map((seat) => (
@@ -1679,7 +1759,9 @@ function OfficeSettingsPanel({
           </div>
         ))}
       </div>
+      ) : undefined}
 
+      {showEmployeeSettings ? (
       <div className="gomi-settings-group">
         <div className="gomi-settings-title-row">
           <div className="gomi-settings-title">Employees</div>
@@ -1734,7 +1816,9 @@ function OfficeSettingsPanel({
           </div>
         ))}
       </div>
+      ) : undefined}
 
+      {showMemorySettings ? (
       <div className="gomi-settings-group">
         <div className="gomi-settings-title-row">
           <div className="gomi-settings-title">Shared Memory</div>
@@ -1889,7 +1973,9 @@ function OfficeSettingsPanel({
         </label>
         <MemoryBoardPanel memoryItems={memoryItems} />
       </div>
+      ) : undefined}
 
+      {showExecutionSettings ? (
       <div className="gomi-settings-group">
         <div className="gomi-settings-title">Execution Policy</div>
         <div className="gomi-memory-summary">
@@ -1966,6 +2052,13 @@ function OfficeSettingsPanel({
           />
         </label>
       </div>
+      ) : undefined}
+
+      {settingsSearchTerms.length > 0 && visibleSettingsGroupCount === 0 ? (
+        <div className="gomi-settings-empty" role="status">
+          No settings match "{settingsSearchQuery}".
+        </div>
+      ) : undefined}
     </section>
   );
 }

--- a/src/vs/workbench/contrib/gomi/common/settingsSearch.ts
+++ b/src/vs/workbench/contrib/gomi/common/settingsSearch.ts
@@ -10,24 +10,47 @@ export interface SearchableField {
   section: string;
 }
 
+function stringifySearchPart(value: unknown): string {
+  if (value === undefined || value === null) {
+    return '';
+  }
+
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  }
+
+  return String(value);
+}
+
+export function matchesSettingsSearch(parts: unknown[], query: string): boolean {
+  const terms = query.toLowerCase().trim().split(/\s+/).filter(Boolean);
+  if (terms.length === 0) {
+    return true;
+  }
+
+  const searchText = parts.map(stringifySearchPart).join(' ').toLowerCase();
+  return terms.every((term) => searchText.includes(term));
+}
+
 export function searchSettings(
   fields: SearchableField[],
   query: string
 ): SearchableField[] {
-  if (!query.trim()) return fields;
-
-  const terms = query.toLowerCase().trim().split(/\s+/);
-
-  return fields.filter((field) => {
-    const searchText = [
-      field.key.toLowerCase(),
-      field.label.toLowerCase(),
-      String(field.value ?? '').toLowerCase(),
-      field.section.toLowerCase(),
-    ].join(' ');
-
-    return terms.every((term) => searchText.includes(term));
-  });
+  return fields.filter((field) =>
+    matchesSettingsSearch(
+      [
+        field.key.toLowerCase(),
+        field.label.toLowerCase(),
+        String(field.value ?? '').toLowerCase(),
+        field.section.toLowerCase(),
+      ],
+      query
+    )
+  );
 }
 
 export function buildSettingsSearchIndex(

--- a/tests/settingsSearch.test.ts
+++ b/tests/settingsSearch.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { searchSettings, buildSettingsSearchIndex } from '../src/vs/workbench/contrib/gomi/common/settingsSearch';
+import {
+  buildSettingsSearchIndex,
+  matchesSettingsSearch,
+  searchSettings
+} from '../src/vs/workbench/contrib/gomi/common/settingsSearch';
 
 describe('settingsSearch', () => {
   const fields = [
@@ -28,5 +32,10 @@ describe('settingsSearch', () => {
     });
     expect(idx.length).toBeGreaterThan(0);
     expect(idx.find((f) => f.key === 'memory.retentionDays')).toBeTruthy();
+  });
+
+  it('matches multi-term section metadata', () => {
+    expect(matchesSettingsSearch(['Shared Memory', { retentionDays: 30 }], 'memory retention')).toBe(true);
+    expect(matchesSettingsSearch(['Execution Policy', { allowHttpProviders: true }], 'memory retention')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Adds a keyboard-accessible search box to the Office Settings panel.
- Filters the main settings sections by multi-term queries across section labels and nested settings metadata.
- Shows matched setting chips and an empty state when no settings match.
- Reuses the existing settings search helper and adds test coverage for multi-term section matching.

Fixes #43.

## Validation
- `npx vitest run tests/settingsSearch.test.ts` (5 tests passed)
- `npm run verify:release` (8 tests passed)
- `npx vite build --outDir build/gomi-office-webview --emptyOutDir` (passed; existing large chunk warning only)
- `git diff --check` (passed)

## Notes
- `npm run typecheck` still fails on existing upstream issues unrelated to this PR, including `gomiPatchApproval.test.ts` test runner globals, missing `zod` type resolution, and pre-existing unused/strictness errors in other files.