### PR TITLE
[25 MRG] a11y: toast slide-in animation + reduced-motion support (fixes #18)

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -86,6 +86,24 @@ button {
   background: #111827;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.32);
   color: #f8fafc;
+  animation: gomi-toast-slide-in 220ms ease-out;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .gomi-toast {
+    animation: none;
+  }
+}
+
+@keyframes gomi-toast-slide-in {
+  from {
+    opacity: 0;
+    transform: translateX(24px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
 }
 
 .gomi-toast[data-status='blocked'] {


### PR DESCRIPTION
## What

Add CSS slide-in animation for agent status toasts and respect prefers-reduced-motion for accessibility:
- Slide-in animation on toast appearance (opacity fade + translateX slide from right, 220ms)
- @media (prefers-reduced-motion: reduce) disables animation entirely
- Green left border for done, red for blocked (pre-existing)

## Why

Issue #18 requires toast notifications when agents flip to done or blocked. The core logic (queue, dedup, max 3, click-to-focus, dismiss) was already in place. This PR adds the missing visual polish: smooth entry animation and reduced-motion respect to meet the acceptance criteria.

## Testing

- Existing gomiStatusToasts.test.ts passes
- Visual: animation tested via prefers-reduced-motion media query

Fixes: #18
Ref: mergeos#244