### PR TITLE
feat(electron): add fail-closed auto-update policy (#29)

### DIFF
--- a/docs/windows-release.md
+++ b/docs/windows-release.md
@@ -149,3 +149,35 @@ VS Code's Windows setup path uses Inno Setup. MSI is not the primary upstream pa
 ## Current Limitation
 
 This repository is still a Gomi product foundation and module scaffold. A full release requires validating the native workbench contribution and patch diff preview inside a real Code - OSS fork, deepening terminal scrollback and workbench log/output-channel readers beyond the current adapter hooks, and replacing all final branding assets.
+
+## Auto-Update (optional, off by default)
+
+Packaged builds ship with auto-update plumbing that is **disabled unless explicitly
+configured**. `shouldCheckForUpdates()` in
+`src/vs/workbench/contrib/gomi/node/autoUpdaterStub.ts` gates every update check and
+fails closed: a default packaged build makes no network call because the feature flag
+is absent.
+
+An update check requires **all** of the following:
+
+| Condition | Reason |
+|---|---|
+| `enabled === true` | Opt-in only; absent or `false` keeps updates off |
+| `isPackaged === true` | Dev and test runs must never reach a real feed |
+| A valid feed (`owner/repo`, or an `https://` URL for `generic`) | Enabled-but-unconfigured is a misconfiguration, not a reason to guess |
+| `electron-updater` resolvable | Optional dependency; absent means no updater |
+
+Each rejection returns a machine-readable `reason` (`disabled`, `not-packaged`,
+`no-feed`, `updater-unavailable`) so callers can log the decision without re-deriving it.
+
+### Security considerations
+
+- **No silent downloads.** `autoDownload` is `false`; an update is only fetched after
+  an explicit check, and installs are deferred to app quit.
+- **HTTPS is required for generic feeds.** A plain `http://` URL is rejected, since an
+  update feed over cleartext is trivially spoofable and would allow an attacker to
+  serve an arbitrary binary.
+- **No implicit feed.** Nothing is inferred from the environment; an unconfigured build
+  contacts nothing.
+- **Signing is still outstanding.** The updater is wired but unsigned packages must not
+  be distributed — verify the Windows signing chain before enabling this in production.

--- a/src/vs/workbench/contrib/gomi/node/autoUpdaterStub.ts
+++ b/src/vs/workbench/contrib/gomi/node/autoUpdaterStub.ts
@@ -63,3 +63,57 @@ export function isAutoUpdateAvailable(): boolean {
     return false;
   }
 }
+
+/** Inputs the update policy is allowed to consider. */
+export interface UpdatePolicyInput {
+  /** Feature flag. Absent or false means updates stay off. */
+  enabled?: boolean;
+  /** Feed target: `owner/repo` for github, or an absolute URL for generic. */
+  repo?: string;
+  url?: string;
+  provider?: AutoUpdateConfig["provider"];
+  /** Only packaged builds should ever reach the network. */
+  isPackaged?: boolean;
+}
+
+export interface UpdatePolicyDecision {
+  shouldCheck: boolean;
+  /** Machine-readable reason, so callers can log without re-deriving intent. */
+  reason:
+    | "ok"
+    | "disabled"
+    | "not-packaged"
+    | "no-feed"
+    | "updater-unavailable";
+}
+
+/**
+ * Decide whether a build may contact the update feed.
+ *
+ * Deliberately fail-closed: every unknown or partially configured state
+ * returns false. A default packaged build performs no network call because
+ * `enabled` is absent, which is the property the acceptance criteria pin down.
+ *
+ * Separated from createAutoUpdaterStub so the policy is testable without
+ * electron-updater installed and without touching the network.
+ */
+export function shouldCheckForUpdates(
+  input: UpdatePolicyInput = {},
+  updaterAvailable: () => boolean = isAutoUpdateAvailable,
+): UpdatePolicyDecision {
+  if (input.enabled !== true) return { shouldCheck: false, reason: "disabled" };
+
+  // Dev and test runs must never hit a real feed.
+  if (input.isPackaged !== true) return { shouldCheck: false, reason: "not-packaged" };
+
+  // Enabled but unconfigured is a misconfiguration, not an invitation to guess.
+  const provider = input.provider ?? "github";
+  const hasFeed = provider === "github"
+    ? typeof input.repo === "string" && input.repo.includes("/")
+    : typeof input.url === "string" && /^https:\/\//.test(input.url);
+  if (!hasFeed) return { shouldCheck: false, reason: "no-feed" };
+
+  if (!updaterAvailable()) return { shouldCheck: false, reason: "updater-unavailable" };
+
+  return { shouldCheck: true, reason: "ok" };
+}

--- a/tests/autoUpdaterPolicy.test.ts
+++ b/tests/autoUpdaterPolicy.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Tests for the auto-update policy (issue #29).
+ *
+ * The policy gates every network call, so these cover the default-off
+ * guarantee and each fail-closed path. No electron-updater required.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { shouldCheckForUpdates } from '../src/vs/workbench/contrib/gomi/node/autoUpdaterStub';
+
+const available = () => true;
+const unavailable = () => false;
+
+describe('shouldCheckForUpdates', () => {
+  it('a default packaged build performs no update check', () => {
+    const d = shouldCheckForUpdates({ isPackaged: true }, available);
+    expect(d.shouldCheck).toBe(false);
+    expect(d.reason).toBe('disabled');
+  });
+
+  it('stays off when the flag is explicitly false', () => {
+    expect(shouldCheckForUpdates({ enabled: false, isPackaged: true, repo: 'a/b' }, available).shouldCheck).toBe(false);
+  });
+
+  it('never checks in an unpackaged (dev or test) build', () => {
+    const d = shouldCheckForUpdates({ enabled: true, repo: 'a/b' }, available);
+    expect(d.shouldCheck).toBe(false);
+    expect(d.reason).toBe('not-packaged');
+  });
+
+  it('refuses when enabled but no feed is configured', () => {
+    const d = shouldCheckForUpdates({ enabled: true, isPackaged: true }, available);
+    expect(d.shouldCheck).toBe(false);
+    expect(d.reason).toBe('no-feed');
+  });
+
+  it('rejects a malformed github repo slug', () => {
+    expect(shouldCheckForUpdates({ enabled: true, isPackaged: true, repo: 'notaslug' }, available).reason).toBe('no-feed');
+  });
+
+  it('requires https for a generic feed url', () => {
+    const d = shouldCheckForUpdates({ enabled: true, isPackaged: true, provider: 'generic', url: 'http://example.com/feed' }, available);
+    expect(d.reason).toBe('no-feed');
+  });
+
+  it('refuses when electron-updater is not installed', () => {
+    const d = shouldCheckForUpdates({ enabled: true, isPackaged: true, repo: 'a/b' }, unavailable);
+    expect(d.reason).toBe('updater-unavailable');
+  });
+
+  it('allows a fully configured packaged build', () => {
+    const d = shouldCheckForUpdates({ enabled: true, isPackaged: true, repo: 'mergeos/Gomi' }, available);
+    expect(d.shouldCheck).toBe(true);
+    expect(d.reason).toBe('ok');
+  });
+
+  it('allows a generic https feed', () => {
+    const d = shouldCheckForUpdates(
+      { enabled: true, isPackaged: true, provider: 'generic', url: 'https://updates.example.com/' }, available);
+    expect(d.shouldCheck).toBe(true);
+  });
+
+  it('treats an empty input as off', () => {
+    expect(shouldCheckForUpdates().shouldCheck).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #29. Refs mergeos-bounties/mergeos#244.

## What this adds

`shouldCheckForUpdates()` — the update policy gate the issue asks for. It fails closed: a check happens only when **all four** conditions hold, and each rejection returns a machine-readable `reason` so callers can log the decision without re-deriving it.

| Condition | Rationale |
|---|---|
| `enabled === true` | Opt-in only; absent or `false` keeps updates off |
| `isPackaged === true` | Dev and test runs must never reach a real feed |
| Valid feed (`owner/repo`, or `https://` for `generic`) | Enabled-but-unconfigured is a misconfiguration, not a reason to guess |
| `electron-updater` resolvable | Optional dependency |

Reasons returned: `disabled` · `not-packaged` · `no-feed` · `updater-unavailable` · `ok`

## Acceptance criteria

- [x] **Default packaged build does not call network for updates** — the flag is absent, so the policy returns `disabled` before anything else is evaluated
- [x] **Unit test for `shouldCheckForUpdates` policy** — 10 tests in `tests/autoUpdaterPolicy.test.ts`
- [x] **Docs note in `windows-release.md`** — including the security considerations section

## Security notes

- **No silent downloads.** `autoDownload` stays `false`; installs deferred to app quit.
- **HTTPS required for generic feeds.** Plain `http://` is rejected — a cleartext update feed is trivially spoofable and would let an attacker serve an arbitrary binary. Protocol-relative and `javascript:` URLs are rejected as well.
- **No implicit feed.** Nothing is inferred from the environment; an unconfigured build contacts nothing.
- **Signing still outstanding.** The updater is wired, but unsigned packages should not be distributed.

## Verification

- `tests/autoUpdaterPolicy.test.ts` — **10 passed**
- Full suite: **199 passed** (baseline 189). The 9 pre-existing failing files are unchanged — verified by stashing this branch and re-running.
- `npm run typecheck` — **28 errors before, 28 after**; none in the touched files.

The policy is deliberately separated from `createAutoUpdaterStub` so it can be tested without `electron-updater` installed and without touching the network.