### PR TITLE
feat: desktop release readiness checker (closes #5, mergeos#244)

### DIFF
--- a/docs/windows-release.md
+++ b/docs/windows-release.md
@@ -14,6 +14,28 @@ Gomi repository
 -> Upload ZIP/EXE artifacts to GitHub Releases
 ```
 
+
+## Pre-Release Readiness Check
+
+Before tagging a release, run the desktop release readiness checker to validate that all required branding, icons, and packaging configuration are in place:
+
+```bash
+npm run check:desktop
+```
+
+The checker validates:
+
+- `product.json` — ensures all branding fields are Gomi-specific (name, app ID, extension gallery)
+- `package.json` — verifies electron main entry, build config, and win32 icon path
+- `resources/gomi-branding/` — confirms brand asset directories for win32, darwin, and linux
+- `electron/main.cjs` — validates the electron entry point exists
+
+A non-zero exit means the repository is not ready for desktop packaging. Fix the reported issues before tagging `v*`.
+
+Exit codes:
+- `0` — all checks passed, repository is release-ready
+- `1` — one or more checks failed, see output for details
+
 ## GitHub Actions
 
 The repository includes `.github/workflows/build-release.yml`.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "electron:dev": "node scripts/run-electron-dev.mjs",
     "desktop:dir": "npm run build && electron-builder --win --dir",
     "desktop:build": "npm run build && electron-builder --win",
-    "notarize": "node scripts/notarize.js"
+    "notarize": "node scripts/notarize.js",
+    "check:desktop": "node scripts/check-desktop-release.mjs"
   },
   "dependencies": {
     "@types/three": "^0.185.1",
@@ -63,7 +64,10 @@
       "artifactName": "Gomi-IDE-Setup-${version}-${arch}.${ext}"
     },
     "mac": {
-      "target": ["dmg", "zip"],
+      "target": [
+        "dmg",
+        "zip"
+      ],
       "category": "public.app-category.developer-tools",
       "icon": "resources/gomi-branding/macos/gomi.icns",
       "hardenedRuntime": true,
@@ -72,7 +76,11 @@
       "entitlementsInherit": "build/entitlements.mac.plist"
     },
     "linux": {
-      "target": ["AppImage", "deb", "rpm"],
+      "target": [
+        "AppImage",
+        "deb",
+        "rpm"
+      ],
       "category": "Development",
       "icon": "resources/gomi-branding/linux",
       "maintainer": "gomi@example.com"

--- a/scripts/check-desktop-release.mjs
+++ b/scripts/check-desktop-release.mjs
@@ -1,0 +1,222 @@
+#!/usr/bin/env node
+
+/**
+ * Gomi IDE — Desktop Release Readiness Checker
+ *
+ * Validates that the repository is ready for desktop packaging:
+ *   - product.json branding is Gomi-specific
+ *   - Win32 icon paths are configured
+ *   - Electron main entry is present
+ *   - Branding asset directories exist
+ *
+ * Usage: node scripts/check-desktop-release.mjs
+ * Exit: 0 = ready, 1 = checks failed
+ */
+
+import { access, readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const root = path.resolve(__dirname, '..');
+
+const CHECKS = [];
+let failures = 0;
+
+function check(name, fn) {
+  CHECKS.push({ name, fn });
+}
+
+function fail(message) {
+  failures++;
+  console.error(`  FAIL  ${message}`);
+}
+
+function ok(message) {
+  console.log(`  PASS  ${message}`);
+}
+
+// --- Pure validation functions (exportable for testing) ---
+
+/**
+ * Validate product.json has required Gomi branding fields.
+ * @param {Record<string, unknown>} product
+ * @returns {{ passed: boolean, failures: string[] }}
+ */
+export function validateProductBranding(product) {
+  const failures = [];
+  const required = {
+    nameShort: 'Gomi',
+    nameLong: 'Gomi IDE',
+    applicationName: 'gomi-ide',
+    dataFolderName: '.gomi-ide',
+    win32DirName: 'Gomi IDE',
+    win32NameVersion: 'Gomi IDE',
+    win32AppUserModelId: 'Gomi.IDE',
+    darwinBundleIdentifier: 'com.gomi.ide',
+    linuxIconName: 'gomi-ide',
+    licenseName: 'MIT',
+  };
+
+  for (const [key, expected] of Object.entries(required)) {
+    if (product[key] !== expected) {
+      failures.push(`product.json: ${key} expected "${expected}", got "${product[key]}"`);
+    }
+  }
+
+  // Check extensions gallery is Open VSX (not Microsoft)
+  if (product.extensionsGallery?.serviceUrl !== 'https://open-vsx.org/vscode/gallery') {
+    failures.push('product.json: extensionsGallery.serviceUrl should point to Open VSX');
+  }
+
+  // Check no Microsoft/Visual Studio Code references
+  const text = JSON.stringify(product);
+  if (/Visual Studio Code/i.test(text)) {
+    failures.push('product.json: contains "Visual Studio Code" reference');
+  }
+  if (/Microsoft/i.test(text) && !text.includes('MIT')) {
+    failures.push('product.json: contains "Microsoft" reference');
+  }
+
+  return { passed: failures.length === 0, failures };
+}
+
+/**
+ * Validate package.json has required desktop packaging configuration.
+ * @param {Record<string, unknown>} pkg
+ * @returns {{ passed: boolean, failures: string[] }}
+ */
+export function validatePackageDesktopConfig(pkg) {
+  const failures = [];
+
+  // Electron main entry
+  if (!pkg.main) {
+    failures.push('package.json: missing "main" entry (electron entry point)');
+  }
+
+  // Build config
+  const build = pkg.build;
+  if (!build) {
+    failures.push('package.json: missing "build" configuration (electron-builder)');
+    return { passed: false, failures };
+  }
+
+  if (build.appId !== 'com.gomi.ide') {
+    failures.push(`package.json: build.appId expected "com.gomi.ide", got "${build.appId}"`);
+  }
+
+  if (build.productName !== 'Gomi IDE') {
+    failures.push(`package.json: build.productName expected "Gomi IDE", got "${build.productName}"`);
+  }
+
+  // Win32 config
+  const win = build.win;
+  if (!win) {
+    failures.push('package.json: missing build.win configuration');
+  } else {
+    if (!win.icon) {
+      failures.push('package.json: build.win.icon not set');
+    }
+  }
+
+  return { passed: failures.length === 0, failures };
+}
+
+// --- Runtime checks (need filesystem) ---
+
+async function exists(relativePath) {
+  try {
+    await access(path.join(root, relativePath));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readJson(relativePath) {
+  return JSON.parse(await readFile(path.join(root, relativePath), 'utf8'));
+}
+
+// Register checks
+check('product.json exists', async () => {
+  if (await exists('product.json')) ok('product.json found');
+  else fail('product.json not found');
+});
+
+check('product.json branding', async () => {
+  const product = await readJson('product.json');
+  const result = validateProductBranding(product);
+  if (result.passed) {
+    ok('product.json branding is Gomi-specific');
+  } else {
+    for (const f of result.failures) fail(f);
+  }
+});
+
+check('package.json desktop config', async () => {
+  const pkg = await readJson('package.json');
+  const result = validatePackageDesktopConfig(pkg);
+  if (result.passed) {
+    ok('package.json has required desktop packaging config');
+  } else {
+    for (const f of result.failures) fail(f);
+  }
+});
+
+check('electron main entry exists', async () => {
+  const entry = (await readJson('package.json')).main || 'electron/main.cjs';
+  if (await exists(entry)) ok(`electron main entry: ${entry}`);
+  else fail(`electron main entry not found: ${entry}`);
+});
+
+check('win32 icon configured', async () => {
+  const pkg = await readJson('package.json');
+  const icon = pkg?.build?.win?.icon;
+  if (icon) {
+    ok(`win32 icon path: ${icon}`);
+  } else {
+    fail('win32 icon path not configured in package.json build.win.icon');
+  }
+});
+
+check('branding assets directory', async () => {
+  if (await exists('resources/gomi-branding')) {
+    const dirs = ['win32', 'darwin', 'linux'];
+    let allGood = true;
+    for (const d of dirs) {
+      if (await exists(`resources/gomi-branding/${d}`)) {
+        ok(`branding assets: resources/gomi-branding/${d}/`);
+      } else {
+        fail(`branding assets missing: resources/gomi-branding/${d}/`);
+        allGood = false;
+      }
+    }
+    if (allGood) ok('all branding asset directories present');
+  } else {
+    fail('resources/gomi-branding/ directory not found');
+  }
+});
+
+// --- Run ---
+console.log('\nGomi IDE — Desktop Release Readiness Checker\n');
+
+for (const { name, fn } of CHECKS) {
+  console.log(`[${name}]`);
+  try {
+    await fn();
+  } catch (err) {
+    fail(`Unexpected error: ${err.message}`);
+  }
+  console.log();
+}
+
+const total = CHECKS.length;
+console.log(`Results: ${total - failures}/${total} checks passed`);
+
+if (failures > 0) {
+  console.error(`\n${failures} check(s) failed. Fix the issues above before tagging a release.`);
+  process.exit(1);
+} else {
+  console.log('✅ All checks passed. Repository is ready for desktop release.\n');
+  process.exit(0);
+}


### PR DESCRIPTION
## What

Adds a desktop release readiness checker per #5 (MergeOS prj_0127 / mergeos#244).

### Changes

**New: **
- CLI script that validates repository readiness for desktop packaging
- Pure validation functions (exportable for testing): , 
- Checks: product.json branding, package.json build config, electron main entry, win32 icon path, branding asset directories
- Exits non-zero on failure, 0 on success

**Updated: **
- Added  npm script: 

**Updated: **
- Added "Pre-Release Readiness Check" section with usage instructions and exit code reference

### Verification



Example output:


### Related
- Closes #5
- mergeos#244 (prj_0127 / tsk_0128)
